### PR TITLE
Add support for receiving flattened jwe

### DIFF
--- a/src/messages/jwe.rs
+++ b/src/messages/jwe.rs
@@ -4,7 +4,7 @@ use crate::{
     Jwk,
     JwmHeader,
     Recepient,
-    messages::serialization::{base64_buffer, base64_jwm_header},
+    messages::serialization::base64_jwm_header,
 };
 
 macro_rules! create_getter {
@@ -23,16 +23,6 @@ macro_rules! create_getter {
             None
         }
     };
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub struct RecipientValue {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub header: Option<Jwk>,
-
-	#[serde(with="base64_buffer")]
-    #[serde(default)]
-    pub encrypted_key: Vec<u8>,
 }
 
 /// JWE representation of `Message` with public header.
@@ -58,10 +48,6 @@ pub struct Jwe {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tag: Option<String>,
-
-    #[serde(flatten)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub recipient_value: Option<RecipientValue>,
 }
 
 impl Jwe {
@@ -71,7 +57,6 @@ impl Jwe {
         recepients: Option<Vec<Recepient>>,
         ciphertext: impl AsRef<[u8]>,
         protected: Option<JwmHeader>,
-        recipient_value: Option<RecipientValue>,
         tag: Option<impl AsRef<[u8]>>,
         iv_input: Option<String>,
     ) -> Self {
@@ -94,7 +79,6 @@ impl Jwe {
             ciphertext: encode(ciphertext.as_ref()),
             protected,
             iv,
-            recipient_value,
             tag: tag_value,
         }
     }
@@ -136,7 +120,6 @@ fn default_jwe_with_random_iv() {
         None,
         None,
         vec![],
-        None,
         None,
         Some(vec![]),
         None,

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -1210,7 +1210,7 @@ mod jwe_flat_json_tests {
     use utilities::{KeyPairSet, get_keypair_set};
 
     #[test]
-    fn can_create_flat_jwe_jsons() -> Result<(), Error> {
+    fn can_create_flat_jwe_json() -> Result<(), Error> {
         let KeyPairSet { alice_private, bobs_public, ..  } = get_keypair_set();
         let sign_keypair = ed25519_dalek::Keypair::generate(&mut OsRng);
         let message = Message::new()
@@ -1237,7 +1237,7 @@ mod jwe_flat_json_tests {
     }
 
     #[test]
-    fn can_receive_flat_jwe_jsons() -> Result<(), Error> {
+    fn can_receive_flat_jwe_json() -> Result<(), Error> {
         let KeyPairSet {
             alice_private,
             alice_public,

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -1280,10 +1280,3 @@ mod jwe_flat_json_tests {
         Ok(())
     }
 }
-
-/*
-
-    pub header: Jwk,
-    pub encrypted_key: Strin
-
-*/

--- a/src/messages/raw.rs
+++ b/src/messages/raw.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use base64_url::{decode, encode};
 use serde_json::Value;
 
-use crate::{DidcommHeader, Error, Jwe, Jws, MessageType, crypto::{
+use crate::{DidcommHeader, Error, Jwe, Jws, crypto::{
         SignatureAlgorithm,
         SymmetricCypherMethod,
         SigningMethod,
@@ -57,7 +57,6 @@ impl Message {
                 self.recepients.clone(),
                 cyphertext.to_vec(),
                 Some(header),
-                None,
                 Some(tag),
                 Some(iv),
             );

--- a/src/messages/raw.rs
+++ b/src/messages/raw.rs
@@ -52,14 +52,34 @@ impl Message {
                 aad,
             )?;
             let (cyphertext, tag) = cyphertext_and_tag.split_at(cyphertext_and_tag.len() - 16);
-            let jwe = Jwe::new(
-                None,
-                self.recepients.clone(),
-                cyphertext.to_vec(),
-                Some(header),
-                Some(tag),
-                Some(iv),
-            );
+            let jwe;
+            if self.serialize_flat_jwe {
+                let recepients = self.recepients
+                    .ok_or_else(||
+                        Error::Generic("flat JWE JSON serialization needs a recipient".to_string()))?;
+                if recepients.len() != 1 {
+                    return Err(
+                        Error::Generic("flat JWE JSON serialization needs exactly one recipient".to_string()));
+                }
+
+                jwe = Jwe::new_flat(
+                    None,
+                    recepients[0].clone(),
+                    cyphertext.to_vec(),
+                    Some(header),
+                    Some(tag),
+                    Some(iv),
+                );
+            } else {
+                jwe = Jwe::new(
+                    None,
+                    self.recepients.clone(),
+                    cyphertext.to_vec(),
+                    Some(header),
+                    Some(tag),
+                    Some(iv),
+                );
+            }
             Ok(serde_json::to_string(&jwe)?)
     }
     /// Decrypts received cypher into instance of `Message`.


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Adds support for receiving and creating flattened JWE JSON messages.

## Details

<!--- HOW does it change stuff? -->

- flat JWE JSON need to have exactly **one** recipient
- to enable flat serialization add `as_flat_jwe()` to the `Message` function chain
- `as_flat_jwe()` **does not replace** `as_jwe(...)` as it just sets an additional flag in the `Message` object, both have to be called to create valid JWE JSON documents