### PR TITLE
Add support for receiving general jws

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 [dependencies]
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["raw_value"] }
 base64-url = "1.4.9"
 # Raw crypto dependancies
 chacha20poly1305 = { version = "0.8", optional = true }

--- a/src/messages/jws.rs
+++ b/src/messages/jws.rs
@@ -20,20 +20,42 @@ macro_rules! create_getter {
     };
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SignatureValue {
     #[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(with="base64_jwm_header")]
-    #[serde(default)]
     pub protected: Option<JwmHeader>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub header: Option<JwmHeader>,
+
 	#[serde(with="base64_buffer")]
-    #[serde(default)]
     pub signature: Vec<u8>,
 }
 
 impl SignatureValue {
+    /// Creates a new `SignatureValue` that can be used in JWS `signatures` property or
+    /// as top-level (flattened) property in flattened JWS JSON serialization.
+    /// 
+    /// # Parameters
+    ///
+    /// `protected` - JWM header protected by signing
+    ///
+    /// `header` - JWM header not protected by signing
+    ///
+    /// `signature` - signature over JWS payload and protected header
+    pub fn new(
+        protected: Option<JwmHeader>,
+        header: Option<JwmHeader>,
+        signature: Vec<u8>,
+    ) -> Self {
+        SignatureValue {
+            protected,
+            header,
+            signature,
+        }
+    }
+
     create_getter!(enc, String);
     create_getter!(kid, String);
     create_getter!(skid, String);
@@ -47,24 +69,48 @@ impl SignatureValue {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Jws {
     pub payload: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signatures: Option<Vec<SignatureValue>>,
     #[serde(flatten)]
-    pub signature_value: SignatureValue,
+    pub signature_value: Option<SignatureValue>,
 }
 
 impl Jws {
+    /// Creates a new [general JWS](https://datatracker.ietf.org/doc/html/rfc7515#section-7.2.1)
+    /// object with signature values per recipient.
+    /// 
+    /// # Parameters
+    ///
+    /// `payload` - payload with encoded data
+    ///
+    /// `signatures` - signature values per recipient
     pub fn new(
         payload: String,
-        protected: Option<JwmHeader>,
-        header: Option<JwmHeader>,
-        signature: Vec<u8>,
+        signatures: Vec<SignatureValue>,
     ) -> Self {
         Jws {
             payload,
-            signature_value: SignatureValue {
-                protected,
-                header,
-                signature,
-            },
+            signature_value: None,
+            signatures: Some(signatures),
+        }
+    }
+
+    /// Creates a new [flattened JWS](https://datatracker.ietf.org/doc/html/rfc7515#section-7.2.2)
+    /// object with signature information on JWS' top level.
+    /// 
+    /// # Parameters
+    ///
+    /// `payload` - payload with encoded data
+    ///
+    /// `signatures` - signature value that is used on JWS top-level
+    pub fn new_flat(
+        payload: String,
+        signature_value: SignatureValue,
+    ) -> Self {
+        Jws {
+            payload,
+            signature_value: Some(signature_value),
+            signatures: None,
         }
     }
 }

--- a/src/messages/jws.rs
+++ b/src/messages/jws.rs
@@ -70,13 +70,13 @@ impl Signature {
 pub struct Jws {
     pub payload: String,
 
-    /// Top-level signature signature for flat JWS JSON messages.
+    /// Top-level signature for flat JWS JSON messages.
     /// Will be ignored if `signatures` is not `None`
     #[serde(flatten)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<Signature>,
 
-    /// Pre-recipient signatures for flat JWs JSON messages.
+    /// Pre-recipient signatures for flat JWS JSON messages.
     /// If not `None`, will be preferred over `signature`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signatures: Option<Vec<Signature>>,

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -68,7 +68,7 @@ pub struct Message {
     /// Not part of the serialized JSON and ignored when deserializing.
     #[serde(skip)]
     pub serialize_flat_jwe: bool,
-    /// Flag that toggles JWs serialization to flat JSON.
+    /// Flag that toggles JWS serialization to flat JSON.
     /// Not part of the serialized JSON and ignored when deserializing.
     #[serde(skip)]
     pub serialize_flat_jws: bool,

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -45,7 +45,7 @@ use crate::crypto::{
 };
 use std::convert::TryFrom;
 use sha2::{Digest, Sha256};
-use crate::{Error, Jwe, Jws, MessageType, SignatureValue};
+use crate::{Error, Jwe, Jws, MessageType, Signature};
 
 /// DIDComm message structure.
 /// [Specification](https://identity.foundation/didcomm-messaging/spec/#message-structure)
@@ -735,7 +735,7 @@ impl Message {
         if to_check.iv.is_some() {
             return Ok(MessageType::DidcommJwe);
         }
-        if to_check.signature.is_some() || to_check.signatures.is_some() {
+        if to_check.signatures.is_some() || to_check.signature.is_some() {
             return Ok(MessageType::DidcommJws);
         }
         let message: Message = serde_json::from_str(message)?;
@@ -814,8 +814,8 @@ impl Message {
             ).map_err(|_| Error::JwsParseError)?;
             message_verified = Some(Message::verify(to_verify, &kid)?);
         } else if let Ok(jws) = serde_json::from_str::<Jws>(&incomming) {
-            let signatures_values_to_verify: Vec<SignatureValue>;
-            if let Some(signature_value) = jws.signature_value {
+            let signatures_values_to_verify: Vec<Signature>;
+            if let Some(signature_value) = jws.signature {
                 signatures_values_to_verify = vec![signature_value.clone()];
             } else if let Some(signatures) = &jws.signatures {
                 signatures_values_to_verify = signatures.clone();


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Adds support for receiving and creating flattened JWS JSON messages.

## Details

<!--- HOW does it change stuff? -->

- flat JWS JSON need to have exactly **one** to
- to enable flat serialization use `as_flat_jwe()` instead of `as_jwe()` in the `Message` function chain
- `as_flat_jwe` has been updated to act as replacement for `as_jwe` as well
- variable and type names of JWE `recipients` and JWS `singatures` has been updted to reflect their similarity in behavior