### PR TITLE
Add support for passing signature public key

### DIFF
--- a/src/crypto/encryptor.rs
+++ b/src/crypto/encryptor.rs
@@ -115,8 +115,8 @@ impl Cypher for CryptoAlgorithm {
 
 impl TryFrom<&String> for CryptoAlgorithm {
     type Error = Error;
-    fn try_from(incomming: &String) -> Result<Self, Error> {
-        match &incomming[..] {
+    fn try_from(incoming: &String) -> Result<Self, Error> {
+        match &incoming[..] {
             "ECDH-1PU+A256KW" => Ok(Self::A256GCM),
             "ECDH-1PU+XC20PKW" => Ok(Self::XC20P),
             _ => return Err(Error::JweParseError),

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -41,9 +41,9 @@ fn send_receive_raw() {
 
     // receiving raw message
     #[cfg(not(feature = "resolve"))]
-    let received = Message::receive(&ready_to_send, &[0; 32], None);
+    let received = Message::receive(&ready_to_send, &[0; 32], None, None);
     #[cfg(feature = "resolve")]
-    let received = Message::receive(&ready_to_send, b"");
+    let received = Message::receive(&ready_to_send, b"", None, None);
 
     // Assert
     assert_eq!(m, received.unwrap());
@@ -71,7 +71,12 @@ fn send_receive_mediated_encrypted_xc20p_json_test_new() {
         );
     assert!(sealed.is_ok());
 
-    let mediator_received = Message::receive(&sealed.unwrap(), &mediators_private, Some(&alice_public));
+    let mediator_received = Message::receive(
+        &sealed.unwrap(),
+        &mediators_private,
+        Some(&alice_public),
+        None,
+    );
     assert!(mediator_received.is_ok());
 
     let mediator_received_unwrapped = mediator_received.unwrap().get_body().unwrap();
@@ -83,7 +88,10 @@ fn send_receive_mediated_encrypted_xc20p_json_test_new() {
     assert!(str_jwe.is_ok());
 
     let bob_received = Message::receive(
-        &String::from_utf8_lossy(&message_to_forward.payload), &bobs_private, Some(&alice_public),
+        &String::from_utf8_lossy(&message_to_forward.payload),
+        &bobs_private,
+        Some(&alice_public),
+        None,
     );
     assert!(bob_received.is_ok());
 }
@@ -214,9 +222,16 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
     let received = Message::receive(
         &ready_to_send,
         &bobs_private,
-        Some(&alice_public)); // and now we parse received
+        Some(&alice_public),
+        None,
+    );
     #[cfg(feature = "resolve")]
-    let received = Message::receive(&ready_to_send, &"HBTcN2MrXNRj9xF9oi8QqYyuEPv3JLLjQKuEgW9oxVKP".from_base58().unwrap());
+    let received = Message::receive(
+        &ready_to_send,
+        &"HBTcN2MrXNRj9xF9oi8QqYyuEPv3JLLjQKuEgW9oxVKP".from_base58().unwrap(),
+        None,
+        None,
+    );
 
     // Assert
     assert!(&received.is_ok());

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -40,10 +40,7 @@ fn send_receive_raw() {
 
 
     // receiving raw message
-    #[cfg(not(feature = "resolve"))]
-    let received = Message::receive(&ready_to_send, &[0; 32], None, None);
-    #[cfg(feature = "resolve")]
-    let received = Message::receive(&ready_to_send, b"", None, None);
+    let received = Message::receive(&ready_to_send, None, None, None);
 
     // Assert
     assert_eq!(m, received.unwrap());
@@ -73,7 +70,7 @@ fn send_receive_mediated_encrypted_xc20p_json_test_new() {
 
     let mediator_received = Message::receive(
         &sealed.unwrap(),
-        &mediators_private,
+        Some(&mediators_private),
         Some(&alice_public),
         None,
     );
@@ -89,7 +86,7 @@ fn send_receive_mediated_encrypted_xc20p_json_test_new() {
 
     let bob_received = Message::receive(
         &String::from_utf8_lossy(&message_to_forward.payload),
-        &bobs_private,
+        Some(&bobs_private),
         Some(&alice_public),
         None,
     );
@@ -221,7 +218,7 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
     #[cfg(not(feature = "resolve"))]
     let received = Message::receive(
         &ready_to_send,
-        &bobs_private,
+        Some(&bobs_private),
         Some(&alice_public),
         None,
     );


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Adds support to pass a custom key to `receive` and `verify` which is used to verify the JWS signature(s).

## Details

<!--- HOW does it change stuff? -->

- add argument to pass verification public key
- make all keys (2x encryption, 1x signing) optional arguments in `receive` as depending on input (plain, signed, sealed) different keys may be needed (or none at all)