### PR TITLE
Set default value for body to empty object

### DIFF
--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -1203,7 +1203,7 @@ mod crypto_tests {
 }
 
 #[cfg(test)]
-mod serialization_type_tests {
+mod serialization_tests {
     use super::*;
 
     use k256::elliptic_curve::rand_core::OsRng;


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

As body is mandatory and should be an empty object if not needed, update code to follow this definition from spec.

## Details

<!--- HOW does it change stuff? -->
- use empty object as `Message` constructors default value for body