### PR TITLE
Preserve `typ` of inner message during signing/encrypting

### DIFF
--- a/src/messages/headers.rs
+++ b/src/messages/headers.rs
@@ -124,7 +124,6 @@ impl JwmHeader {
     /// Modifies `typ` and `alg` headers.
     ///
     pub fn as_signed(&mut self, alg: &SignatureAlgorithm) {
-        self.typ = MessageType::DidcommJws;
         match alg {
             SignatureAlgorithm::EdDsa => {
                 self.alg = Some(String::from("EdDSA"));
@@ -141,7 +140,6 @@ impl JwmHeader {
     /// Modifies `enc`, `typ` and `alg` headers.
     ///
     pub fn as_encrypted(&mut self, alg: &CryptoAlgorithm) {
-        self.typ = MessageType::DidcommJwe;
         match alg {
             CryptoAlgorithm::A256GCM => {
                 self.enc = Some("A256GCM".into());


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Updates signing and encryption to leave inner messages/envelopes `typ` unchanged. E.g. an inner JWM message will now stay `"application/didcomm-plain+json"` when signed.

## Details

<!--- HOW does it change stuff? -->

- updating `typ` has been moved into signing/encrypting the message, therefore the payload that is signed/encrypted stays untouched
- signing has been updated to preserve inner messages header values AND the JWS envelopes header values