### PR TITLE
Update documentation and align naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ regex = "1"
 rand = "0.8"
 rand_chacha = "0.3.0"
 thiserror = "1.0"
+paste = "1.0.5"
 
 [dev-dependencies]
 sodiumoxide = "0.2.6"

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ When implemented - use them instead of `CryptoAlgorithm` and `SignatureAlgorithm
 
 ### GoTo: [full test][shape_desired_test]
 
-In most cases application implementation would prefer to have strongly typed body of the message instead of raw `Vec<u8>`.
+In most cases application implementation would prefer to have strongly typed body of the message instead of raw `String`.
 For this scenario `Shape` trait should be implemented for target type.
 
 * First, let's define our target type. JSON in this example.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ let message = Message::new()
     // set `kid` property
     .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#);
 
-// receiver public key is automatically resolved
+// recipient public key is automatically resolved
 let ready_to_send = message.seal(&ek, Some(&bobs_public)).unwrap();
 
 //... transport is happening here ...
@@ -205,7 +205,7 @@ let received = Message::receive(
 ); // and now we parse received
 ```
 
-### 6. Multiple receivers static key wrap per recipient with shared secret
+### 6. Multiple recipients static key wrap per recipient with shared secret
 
 * ! Works with `resolve` feature only - requires resolution of public keys for each recipient for shared secret generation.
 * Static key generated randomly in the background (`to` field has >1 recipient).
@@ -228,7 +228,7 @@ assert!(jwe.is_ok());
 
 let jwe = jwe.unwrap();
 
-// Each of the recipients receive it in same way as before (direct with single receiver)
+// Each of the recipients receive it in same way as before (direct with single recipient)
 let received_first = Message::receive(&jwe, Some(&bobs_private), None, None);
 let received_second = Message::receive(&jwe, Some(&clarice_private), None, None);
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ assert!(received_second.is_ok());
 
 ## Pluggable cryptography
 
-In order to use your own implementation[s] of message crypto and/or signature algorithms implement these trait[s]:
+In order to use your own implementation(s) of message crypto and/or signature algorithms implement these trait(s):
 
 [`didcomm_rs::crypto::Cypher`][crypter]
 
@@ -302,4 +302,4 @@ This is a sample implementation of the DIDComm V2 spec. The DIDComm V2 spec is s
 [send_receive_direct_signed_and_encrypted_xc20p_test]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L164
 [send_receive_didkey_test]: https://github.com/evannetwork/didcomm-rs/blob/master/src/messages/message.rs#L482
 [shape_desired_test]: https://github.com/evannetwork/didcomm-rs/blob/main/tests/shape.rs#L21
-[signer]: https://github.com/decentralized-identity/didcomm-rs/blob/master/src/crypto/mod.rs#L39
+[signer]: https://github.com/evannetwork/didcomm-rs/blob/master/src/crypto/mod.rs#L39

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ let m = Message::new()
         "did:xyz:30489jnutnjqhiu0uh540u8hunoe",
     ])
     // populating body with some data - `Vec<bytes>`
-    .set_body(TEST_DID);
+    .body(TEST_DID);
 
 // Serialize message into JWM json (SENDER action)
 let ready_to_send = m.clone().as_raw_json().unwrap();
@@ -54,7 +54,7 @@ let message = Message::new()
         "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
     ])
     // packing in some payload (can be anything really)
-    .set_body(TEST_DID)
+    .body(TEST_DID)
     // decide which [Algorithm](crypto::encryptor::CryptoAlgorithm) is used (based on key)
     .as_jwe(
         &CryptoAlgorithm::XC20P,
@@ -83,7 +83,7 @@ let ready_to_send = message.seal(&ek, Some(&bobs_public)).unwrap();
 let message = Message::new() // creating message
     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
     .to(&["did::xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"]) // setting to
-    .set_body(TEST_DID) // packing in some payload
+    .body(TEST_DID) // packing in some payload
     .as_jws(&SignatureAlgorithm::EdDsa)
     .sign(SignatureAlgorithm::EdDsa.signer(), &sign_keypair.to_bytes()).unwrap();
 
@@ -109,7 +109,7 @@ let mediated = Message::new()
     // setting to
     .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
     // packing in some payload
-    .set_body(r#"{"foo":"bar"}"#)
+    .body(r#"{"foo":"bar"}"#)
     // set JOSE header for XC20P algorithm
     .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
     // custom header
@@ -180,7 +180,7 @@ let KeyPairSet {
 let message = Message::new() // creating message
     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
     .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
-    .set_body(TEST_DID) // packing in some payload
+    .body(TEST_DID) // packing in some payload
     .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
     .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
     .add_header_field("another_key".into(), "another_value".into()) // another custom header
@@ -286,7 +286,7 @@ let body = r#"{"num_field":123,"string_field":"foobar"}"#.to_string();
 let message = Message::new() // creating message
     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
     .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
-    .set_body(&body); // packing in some payload
+    .body(&body); // packing in some payload
 let received_typed_body = DesiredShape::shape(&message).unwrap(); // Where m = Message
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,216 +4,241 @@ Rust implementation of DIDComm v2 [spec](https://identity.foundation/didcomm-mes
 
 ![tests](https://github.com/decentralized-identity/didcomm-rs/workflows/tests/badge.svg)
 
-# License
+## License
 
 [Apache-2.0](LICENSE.md)
 
-# Examples of usage
+## Examples of usage
 
-## 1. Prepare raw message for send and receive
+### 1. Prepare raw message for send and receive
 
-### GoTo: [full test](https://github.com/decentralized-identity/didcomm-rs/blob/master/tests/send_receive.rs#L12)
+#### GoTo: [full test][send_receive_raw]
 
 ```rust
-    // Message construction
-    let m = Message::new()
-        // setting `from` header (sender) - Optional
-        .from("did:xyz:ulapcuhsatnpuhza930hpu34n_")
-        // setting `to` header (recipients) - Optional
-        .to(&["did::xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"])
-        // populating body with some data - `Vec<bytes>`
-        .set_body(some_payload.as_bytes());
+// Message construction
+let m = Message::new()
+    // setting `from` header (sender) - Optional
+    .from("did:xyz:ulapcuhsatnpuhza930hpu34n_")
+    // setting `to` header (recipients) - Optional
+    .to(&[
+        "did::xyz:34r3cu403hnth03r49g03",
+        "did:xyz:30489jnutnjqhiu0uh540u8hunoe",
+    ])
+    // populating body with some data - `Vec<bytes>`
+    .set_body(TEST_DID);
 
-    // Serialize message into JWM json (SENDER action)
-    let ready_to_send = m.as_raw_json().unwrap();
+// Serialize message into JWM json (SENDER action)
+let ready_to_send = m.clone().as_raw_json().unwrap();
 
-    //... transport is happening here ...
+// ... transport is happening here ...
 
-    // On receival deserialize from json into Message (RECEIVER action)
-    // Error handling recommended here
-    let received = Message::receive(&ready_to_send, None).unwrap();
+// On receival deserialize from json into Message (RECEIVER action)
+// Error handling recommended here
+
+let received = Message::receive(&ready_to_send, None, None, None);
 ```
 
-## 2. Prepare JWE message for direct send
+### 2. Prepare JWE message for direct send
 
-### GoTo: [full test](https://github.com/decentralized-identity/didcomm-rs/blob/master/tests/send_receive.rs#L35)
+#### GoTo: [full test][send_receive_encrypted_xc20p_json_test]
 
 ```rust
-    // decide which [Algorithm](crypto::encryptor::CryptoAlgorithm) is used (based on key)
-    let alg = CryptoAlgorithm::XC20P;
-    // key as bytes
-    let ek = [130, 110, 93, 113, 105, 127, 4, 210, 65, 234, 112, 90, 150, 120, 189, 252, 212, 165, 30, 209, 194, 213, 81, 38, 250, 187, 216, 14, 246, 250, 166, 92]
-    // creating message
-    let mut message = Message::new()
+// sender key as bytes
+let ek = [130, 110, 93, 113, 105, 127, 4, 210, 65, 234, 112, 90, 150, 120, 189, 252, 212, 165, 30, 209, 194, 213, 81, 38, 250, 187, 216, 14, 246, 250, 166, 92];
+
+// Message construction
+let message = Message::new()
+    .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
+    .to(&[
+        "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+        "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
+    ])
     // packing in some payload (can be anything really)
-        .set_body(br#"{'key':'value','key2':'value2'}"#)
-    // set JOSE header for XC20P algorithm
-        .as_jwe(alg)
+    .set_body(TEST_DID)
+    // decide which [Algorithm](crypto::encryptor::CryptoAlgorithm) is used (based on key)
+    .as_jwe(
+        &CryptoAlgorithm::XC20P,
+        Some(&bobs_public),
+    )
     // add some custom app/protocol related headers to didcomm header portion
     // these are not included into JOSE header
-        .add_header_field("my_custom_key".into(), "my_custom_value".into())
-        .add_header_field("another_key".into(), "another_value".into());
+    .add_header_field("my_custom_key".into(), "my_custom_value".into())
+    .add_header_field("another_key".into(), "another_value".into())
     // set `kid` property
-    message.jwm_header.kid =
-        Some(String::from(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#));
-    // encrypt and serialize message with JOSE header included
-    let ready_to_send = message.seal(ek.as_bytes())?;
-    // use transport of choice to send `ready_to_send` data to the receiver!
+    .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#);
 
-    //... transport is happening here ...
+// receiver public key is automatically resolved
+let ready_to_send = message.seal(&ek, Some(&bobs_public)).unwrap();
 
+//... transport is happening here ...
 ```
 
-## 3. Prepare JWS message -> send -> receive
+### 3. Prepare JWS message -> send -> receive
 
 * Here `Message` is signed but not encrypted.
 * In such scenarios explicit use of `.sign(...)` and `Message::verify(...)` required.
 
 ```rust
-    // Message construction an JWS wrapping
-    let message = Message::new() // creating message
-        .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
-        .to(&["did::xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"]) // setting to
-        .set_body(sample_dids::TEST_DID_SIGN_1.as_bytes()) // packing in some payload
-        .as_jws(&SignatureAlgorithm::EdDsa)
-        .sign(SignatureAlgorithm::EdDsa.signer(), &sign_keypair.to_bytes()).unwrap();
+// Message construction an JWS wrapping
+let message = Message::new() // creating message
+    .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
+    .to(&["did::xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"]) // setting to
+    .set_body(TEST_DID) // packing in some payload
+    .as_jws(&SignatureAlgorithm::EdDsa)
+    .sign(SignatureAlgorithm::EdDsa.signer(), &sign_keypair.to_bytes()).unwrap();
 
-    //... transport is happening here ...
+//... transport is happening here ...
 
-    // Receiving JWS
-    let received = Message::verify(&message.unwrap().as_bytes(), &sign_keypair.public.to_bytes());
+// Receiving JWS
+let received = Message::verify(&message.as_bytes(), &sign_keypair.public.to_bytes());
 ```
 
-## 4. Prepare JWE message to be mediated -> mediate -> receive
+### 4. Prepare JWE message to be mediated -> mediate -> receive
 
 * Message should be encrypted by destination key first in `.routed_by()` method call using key for the recipient.
 * Next it should be encrypted by mediator key in `.seal()` method call - this can be done multiple times - once for each mediator in chain but should be strictly sequential to match mediators sequence in the chain.
 * Method call `.seal()` **MUST** be preceded by  `.as_jwe(CryptoAlgorithm)` as mediators may use different algorithms and key types than destination and this is not automatically predicted or populated.
 * Keys used for encryption should be used in reverse order - final destination - last mediator - second to last mediator - etc. Onion style.
 
-### GoTo: [full test](https://github.com/decentralized-identity/didcomm-rs/blob/master/tests/send_receive.rs#L67)
+#### GoTo: [full test][send_receive_mediated_encrypted_xc20p_json_test]
 
 ```rust
-    // Message construction
-    let message = Message::new()
-        // setting from
-        .from("did:xyz:ulapcuhsatnpuhza930hpu34n_")
-        // setting to
-        .to(&["did:xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"])
-        // packing in some payload
-        .set_body(some_payload.as_bytes())
-        // set JOSE header for XC20P algorithm
-        .as_jwe(CryptoAlgorithm::XC20P)
-        // custom header
-        .add_header_field("my_custom_key".into(), "my_custom_value".into())
-        // another custom header
-        .add_header_field("another_key".into(), "another_value".into())
-        // set kid header
-        .kid(String::from(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#))
-        // here we use destination key to bob and `to` header of mediator -
-        //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
-        // `ek_to_bob` - destination targeted encryption key
-        .routed_by(ek_to_bob.as_bytes(), vec!("did:mediator:suetcpl23pt23rp2teu995t98u"));
+ // Message construction
+let message = Message::new()
+    // setting from
+    .from("did:xyz:ulapcuhsatnpuhza930hpu34n_")
+    // setting to
+    .to(&["did:xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"])
+    // packing in some payload
+    .set_body(some_payload.as_bytes())
+    // set JOSE header for XC20P algorithm
+    .as_jwe(CryptoAlgorithm::XC20P)
+    // custom header
+    .add_header_field("my_custom_key".into(), "my_custom_value".into())
+    // another custom header
+    .add_header_field("another_key".into(), "another_value".into())
+    // set kid header
+    .kid(String::from(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#))
+    // here we use destination key to bob and `to` header of mediator -
+    //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
+    // `ek_to_bob` - destination targeted encryption key
+    .routed_by(ek_to_bob.as_bytes(), vec!("did:mediator:suetcpl23pt23rp2teu995t98u"));
 
-    // Message envelope to mediator
-    let ready_to_send = message
-        .unwrap() // **ERROR HANDLE** here is recommended
-        .as_jwe(CryptoAlgorithm::XC20P) // here this method call is crucial as mediator and end receiver may use different algorithms.
-        // `ek_to_mediator` - mediator targeted encryption key
-        .seal(ek_to_mediator.as_bytes()); // this would've failed without previous method call.
+// Message envelope to mediator
+let ready_to_send = message
+    .unwrap() // **ERROR HANDLE** here is recommended
+    .as_jwe(CryptoAlgorithm::XC20P) // here this method call is crucial as mediator and end receiver may use different algorithms.
+    // `ek_to_mediator` - mediator targeted encryption key
+    .seal(ek_to_mediator.as_bytes()); // this would've failed without previous method call.
 
-    //... transport to mediator is happening here ...
+//... transport to mediator is happening here ...
 
-    // Received by mediator
-    // `rk_mediator` - key to decrypt mediated message
-    let received_mediated = Message::receive(&ready_to_send.unwrap(), Some(rk_mediator.as_bytes()));
+// Received by mediator
+// `rk_mediator` - key to decrypt mediated message
+let received_mediated = Message::receive(&ready_to_send.unwrap(), Some(rk_mediator.as_bytes()));
 
-    //... transport to destination is happening here ...
+//... transport to destination is happening here ...
 
-    // Received by Bob
-    // `rk_bob` - key to decrypt final message
-    let received_bob = Message::receive(&String::from_utf8_lossy(&received_mediated.unwrap().get_body()?.as_ref()), Some(rk_bob.as_bytes()));
+// Received by Bob
+// `rk_bob` - key to decrypt final message
+let received_bob = Message::receive(
+    &String::from_utf8_lossy(&received_mediated.unwrap().get_body()?.as_ref()),
+    Some(rk_bob.as_bytes()),
+);
 ```
 
-## 5. Prepare JWS envelope wrapped into JWE -> sign -> pack -> receive
+### 5. Prepare JWS envelope wrapped into JWE -> sign -> pack -> receive
 
 * JWS header is set automatically based on signing algorithm type.
 * Message forming and encryption happens in same way as in other JWE examples.
 * ED25519-dalek signature is used in this example with keypair for signing and public key for verification.
 
-### GoTo: [full test](https://github.com/decentralized-identity/didcomm-rs/blob/master/tests/send_receive.rs#L119)
+#### GoTo: [full test][send_receive_direct_signed_and_encrypted_xc20p_test]
 
 ```rust
-    // Message construction
-    let message = Message::new() // creating message
-        .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
-        .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
-        .set_body(sample_dids::TEST_DID_SIGN_1.as_bytes()) // packing in some payload
-        .as_jwe(CryptoAlgorithm::XC20P) // set JOSE header for XC20P algorithm
-        .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
-        .add_header_field("another_key".into(), "another_value".into()) // another custom header
-        .kid(String::from(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#)); // set kid header
+let KeyPairSet {
+    alice_public,
+    alice_private,
+    bobs_private,
+    bobs_public,
+    ..
+} = get_keypair_set();
+// Message construction
+let message = Message::new() // creating message
+    .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
+    .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
+    .set_body(TEST_DID) // packing in some payload
+    .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
+    .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
+    .add_header_field("another_key".into(), "another_value".into()) // another custom header
+    .kid(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#); // set kid header
 
-    // Send as signed and encrypted JWS wrapped into JWE
-    let ready_to_send = message.seal_signed(
-        encryption_key.as_bytes(),
-        &sign_keypair.to_bytes(),
-        SignatureAlgorithm::EdDsa)
-        .unwrap();
+// Send as signed and encrypted JWS wrapped into JWE
+let ready_to_send = message.seal_signed(
+    &alice_private,
+    &sign_keypair.to_bytes(),
+    SignatureAlgorithm::EdDsa,
+    Some(&bobs_public),
+).unwrap();
 
-    //... transport to destination is happening here ...
+//... transport to destination is happening here ...
 
-    //Receive - same method to receive for JWE or JWS wrapped into JWE but with pub verifying key
-    let received = Message::receive(
-        &ready_to_send,
-        Some(decryption_key.as_bytes()),
-        Some(&pub_sign_verify_key.to_bytes())); // and now we parse received
+//Receive - same method to receive for JWE or JWS wrapped into JWE but with pub verifying key
+let received = Message::receive(
+    &ready_to_send,
+    Some(&bobs_private),
+    Some(&alice_public),
+    None,
+); // and now we parse received
 ```
 
-## 6. Multiple receivers static key wrap per recipient with shared secret
+### 6. Multiple receivers static key wrap per recipient with shared secret
 
 * ! Works with `resolve` feature only - requires resolution of public keys for each recipient for shared secret generation.
 * Static key generated randomly in the background (`to` field has >1 recipient).
 
-### GoTo: [full test](https://github.com/decentralized-identity/didcomm-rs/blob/master/src/messages/message.rs#L597)
+#### GoTo: [full test][send_receive_didkey_test]
 
 ```rust
 // Creating message with multiple recipients.
 let m = Message::new()
     .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
-    .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG", "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf"])
-    .as_jwe(&CryptoAlgorithm::XC20P);
+    .to(&[
+        "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
+        "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
+    ])
+    .as_jwe(&CryptoAlgorithm::XC20P, None);
 
-let jwe = m.seal(&sender_private);
+let jwe = m.seal(&alice_private, None);
 // Packing was ok?
 assert!(jwe.is_ok());
 
 let jwe = jwe.unwrap();
 
 // Each of the recipients receive it in same way as before (direct with single receiver)
-let received_first = Message::receive(&jwe, &first_private);
-let received_second = Message::receive(&jwe, &second_private);
+let received_first = Message::receive(&jwe, Some(&bobs_private), None, None);
+let received_second = Message::receive(&jwe, Some(&clarice_private), None, None);
 
 // All good without any extra inputs
 assert!(received_first.is_ok());
 assert!(received_second.is_ok());
 ```
 
-# Pluggable cryptography
+## Pluggable cryptography
 
 In order to use your own implementation[s] of message crypto and/or signature algorithms implement these trait[s]:
 
-[`didcomm_rs::crypto::Cypher`](https://github.com/decentralized-identity/didcomm-rs/blob/master/src/crypto/mod.rs#L30)
+[`didcomm_rs::crypto::Cypher`][crypter]
 
-[`didcomm_rs::crypto::Signer`](https://github.com/decentralized-identity/didcomm-rs/blob/master/src/crypto/mod.rs#L39)
+[`didcomm_rs::crypto::Signer`][signer]
 
 Don't use `default` feature - might change in future.
 
 When implemented - use them instead of `CryptoAlgorithm` and `SignatureAlgorithm` from examples above.
 
-# Strongly typed Message payload (body)
+## Strongly typed Message payload (body)
 
-### GoTo: [full test](https://github.com/decentralized-identity/didcomm-rs/blob/main/tests/shape.rs)
+### GoTo: [full test][shape_desired_test]
 
 In most cases application implementation would prefer to have strongly typed body of the message instead of raw `Vec<u8>`.
 For this scenario `Shape` trait should be implemented for target type.
@@ -234,7 +259,7 @@ struct DesiredShape {
 impl Shape for DesiredShape {
     type Err = Error;
     fn shape(m: &Message) -> Result<DesiredShape, Error> {
-        serde_json::from_slice(&m.body)
+        serde_json::from_str(&m.get_body().unwrap())
             .map_err(|e| Error::SerdeError(e))
     }
 }
@@ -244,9 +269,24 @@ impl Shape for DesiredShape {
 * In this example we expect JSON payload and use it's Deserializer to get our data, but your implementation can work with any serialization.
 
 ```rust
-let received_typed_body = DesiredShape::shape(&m).unwrap(); // Where m = Message
+let body = r#"{"num_field":123,"string_field":"foobar"}"#.to_string();
+let message = Message::new() // creating message
+    .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
+    .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
+    .set_body(&body); // packing in some payload
+let received_typed_body = DesiredShape::shape(&message).unwrap(); // Where m = Message
 ```
 
-# Disclaimer
+## Disclaimer
 
 This is a sample implementation of the DIDComm V2 spec. The DIDComm V2 spec is still actively being developed by the DIDComm WG in the DIF and therefore subject to change.
+
+<!-- Collect links to line numbers here to be able to maintain them easier -->
+[crypter]: https://github.com/evannetwork/didcomm-rs/blob/master/src/crypto/mod.rs#L30
+[send_receive_raw]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L16
+[send_receive_encrypted_xc20p_json_test]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L42
+[send_receive_mediated_encrypted_xc20p_json_test]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L84
+[send_receive_direct_signed_and_encrypted_xc20p_test]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L164
+[send_receive_didkey_test]: https://github.com/evannetwork/didcomm-rs/blob/master/src/messages/message.rs#L482
+[shape_desired_test]: https://github.com/evannetwork/didcomm-rs/blob/main/tests/shape.rs#L21
+[signer]: https://github.com/decentralized-identity/didcomm-rs/blob/master/src/crypto/mod.rs#L39

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ let ready_to_send = message.seal_signed(
 
 //... transport to destination is happening here ...
 
-//Receive - same method to receive for JWE or JWS wrapped into JWE but with pub verifying key
+// Receive - same method to receive for JWE or JWS wrapped into JWE but with pub verifying key
 let received = Message::receive(
     &ready_to_send,
     Some(&bobs_private),

--- a/README.md
+++ b/README.md
@@ -103,48 +103,61 @@ let received = Message::verify(&message.as_bytes(), &sign_keypair.public.to_byte
 #### GoTo: [full test][send_receive_mediated_encrypted_xc20p_json_test]
 
 ```rust
- // Message construction
-let message = Message::new()
+let mediated = Message::new()
     // setting from
-    .from("did:xyz:ulapcuhsatnpuhza930hpu34n_")
+    .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
     // setting to
-    .to(&["did:xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"])
+    .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
     // packing in some payload
-    .set_body(some_payload.as_bytes())
+    .set_body(r#"{"foo":"bar"}"#)
     // set JOSE header for XC20P algorithm
-    .as_jwe(CryptoAlgorithm::XC20P)
+    .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
     // custom header
     .add_header_field("my_custom_key".into(), "my_custom_value".into())
     // another custom header
     .add_header_field("another_key".into(), "another_value".into())
     // set kid header
-    .kid(String::from(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#))
+    .kid(&"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ")
     // here we use destination key to bob and `to` header of mediator -
     //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
-    // `ek_to_bob` - destination targeted encryption key
-    .routed_by(ek_to_bob.as_bytes(), vec!("did:mediator:suetcpl23pt23rp2teu995t98u"));
-
-// Message envelope to mediator
-let ready_to_send = message
-    .unwrap() // **ERROR HANDLE** here is recommended
-    .as_jwe(CryptoAlgorithm::XC20P) // here this method call is crucial as mediator and end receiver may use different algorithms.
-    // `ek_to_mediator` - mediator targeted encryption key
-    .seal(ek_to_mediator.as_bytes()); // this would've failed without previous method call.
+    .routed_by(
+        &alice_private,
+        "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
+        Some(&mediators_public),
+        Some(&bobs_public),
+    );
+assert!(mediated.is_ok());
 
 //... transport to mediator is happening here ...
 
 // Received by mediator
-// `rk_mediator` - key to decrypt mediated message
-let received_mediated = Message::receive(&ready_to_send.unwrap(), Some(rk_mediator.as_bytes()));
+let mediator_received = Message::receive(
+    &mediated.unwrap(),
+    Some(&mediators_private),
+    Some(&alice_public),
+    None,
+);
+assert!(mediator_received.is_ok());
+
+// Get inner JWE as string from message
+let mediator_received_unwrapped = mediator_received.unwrap().get_body().unwrap();
+let pl_string = String::from_utf8_lossy(mediator_received_unwrapped.as_ref());
+let message_to_forward: Mediated = serde_json::from_str(&pl_string).unwrap();
+let attached_jwe = serde_json::from_slice::<Jwe>(&message_to_forward.payload);
+assert!(attached_jwe.is_ok());
+let str_jwe = serde_json::to_string(&attached_jwe.unwrap());
+assert!(str_jwe.is_ok());
 
 //... transport to destination is happening here ...
 
 // Received by Bob
-// `rk_bob` - key to decrypt final message
-let received_bob = Message::receive(
-    &String::from_utf8_lossy(&received_mediated.unwrap().get_body()?.as_ref()),
-    Some(rk_bob.as_bytes()),
+let bob_received = Message::receive(
+    &String::from_utf8_lossy(&message_to_forward.payload),
+    Some(&bobs_private),
+    Some(&alice_public),
+    None,
 );
+assert!(bob_received.is_ok());
 ```
 
 ### 5. Prepare JWS envelope wrapped into JWE -> sign -> pack -> receive

--- a/src/crypto/encryptor.rs
+++ b/src/crypto/encryptor.rs
@@ -10,7 +10,7 @@ use super::*;
 /// Underlying algorithms are implemented by Rust-crypto crate family.
 ///
 /// Allowed (and implemented) cryptographical algorithms (JWA).
-/// According to (spec)[https://identity.foundation/didcomm-messaging/spec/#sender-authenticated-encryption]
+/// According to [spec](https://identity.foundation/didcomm-messaging/spec/#sender-authenticated-encryption)
 #[derive(Copy, Clone)]
 pub enum CryptoAlgorithm {
     XC20P,

--- a/src/crypto/encryptor.rs
+++ b/src/crypto/encryptor.rs
@@ -54,7 +54,7 @@ impl Cypher for CryptoAlgorithm {
 
     /// Generates + invokes crypto of `SymmetricCypherMethod` which performs decryption.
     /// Algorithm selected is based on struct's `CryptoAlgorithm` property.
-    fn decryptor(&self) -> SymmetricCypherMethod {
+    fn decrypter(&self) -> SymmetricCypherMethod {
         match self {
             CryptoAlgorithm::XC20P => Box::new(
                 |nonce: &[u8], key: &[u8], message: &[u8], aad: &[u8]| -> Result<Vec<u8>, Error> {
@@ -140,7 +140,7 @@ mod batteries_tests {
         assert!(&jwe.tag.is_some());
         let s = Message::decrypt(
             &jwe_string.as_bytes(),
-            CryptoAlgorithm::XC20P.decryptor(),
+            CryptoAlgorithm::XC20P.decrypter(),
             key,
         )?;
         let received_payload = &s.get_body()?;
@@ -164,7 +164,7 @@ mod batteries_tests {
         assert!(&jwe.is_ok());
         let s = Message::decrypt(
             &jwe.unwrap().as_bytes(),
-            CryptoAlgorithm::A256GCM.decryptor(),
+            CryptoAlgorithm::A256GCM.decrypter(),
             key,
         )?;
         let received_payload = &s.get_body()?;

--- a/src/crypto/encryptor.rs
+++ b/src/crypto/encryptor.rs
@@ -129,7 +129,7 @@ mod batteries_tests {
         let payload = r#"{"test":"message's body - can be anything..."}"#;
         let m = Message::new()
             .as_jwe(&CryptoAlgorithm::XC20P, None) // Set jwe header manually - should be preceded by key properties
-            .set_body(&payload);
+            .body(&payload);
         let original_header = m.jwm_header.clone();
         let key = b"super duper key 32 bytes long!!!";
         // Act
@@ -156,7 +156,7 @@ mod batteries_tests {
         let payload = r#"{"example":"message's body - can be anything..."}"#;
         let m = Message::new()
             .as_jwe(&CryptoAlgorithm::A256GCM, None) // Set jwe header manually - should be preceded by key properties
-            .set_body(&payload);
+            .body(&payload);
         let original_header = m.jwm_header.clone();
         let key = b"super duper key 32 bytes long!!!";
         // Act

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,3 +1,4 @@
+//! Collection of utilities for cryptography related components.
 pub mod encryptor;
 pub mod signer;
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -27,7 +27,7 @@ pub type ValidationMethod = Box<dyn Fn(&[u8], &[u8], &[u8]) -> Result<bool, Erro
 /// Implemented by `CryptoAlgorithm` with `raw-crypto` feature.
 pub trait Cypher {
     fn encryptor(&self) -> SymmetricCypherMethod;
-    fn decryptor(&self) -> SymmetricCypherMethod;
+    fn decrypter(&self) -> SymmetricCypherMethod;
     fn asymmetric_encryptor(&self) -> AsymmetricCypherMethod;
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -5,7 +5,7 @@ pub mod signer;
 #[cfg(feature = "raw-crypto")]
 pub use {encryptor::CryptoAlgorithm, signer::SignatureAlgorithm};
 
-pub use crate::Error;
+use crate::Error;
 
 /// Return `FnOnce` signature definition for symmetric cryptography method.
 /// Arguments sequence: Nonce, Key, Message.

--- a/src/crypto/signer.rs
+++ b/src/crypto/signer.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use super::*;
 
 /// Signature related batteries for DIDComm.
-/// Implementation of all algorithms required by (spec)[https://identity.foundation/didcomm-messaging/spec/#algorithms]
+/// Implementation of all algorithms required by [spec](https://identity.foundation/didcomm-messaging/spec/#algorithms)
 #[derive(Debug, Clone)]
 pub enum SignatureAlgorithm {
     /// `ed25519` signature

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+/// `Error` type used througout crate
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("plugged cryptography failure")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,6 +427,7 @@ assert!(received_second.is_ok());
 //! [send_receive_didkey_test]: https://github.com/evannetwork/didcomm-rs/blob/master/src/messages/message.rs#L482
 //! [shape_desired_test]: https://github.com/evannetwork/didcomm-rs/blob/main/tests/shape.rs#L21
 //! [signer]: https://github.com/evannetwork/didcomm-rs/blob/master/src/crypto/mod.rs#L39
+#![feature(extended_key_value_attributes)] // allows us to use concat! for doc in getter macro
 extern crate env_logger;
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!         "did:xyz:30489jnutnjqhiu0uh540u8hunoe",
 //!     ])
 //!     // populating body with some data - `Vec<bytes>`
-//!     .set_body(TEST_DID);
+//!     .body(TEST_DID);
 //!
 //! // Serialize message into JWM json (SENDER action)
 //! let ready_to_send = m.clone().as_raw_json().unwrap();
@@ -92,7 +92,7 @@
 //!         "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
 //!     ])
 //!     // packing in some payload (can be anything really)
-//!     .set_body(TEST_DID)
+//!     .body(TEST_DID)
 //!     // decide which [Algorithm](crypto::encryptor::CryptoAlgorithm) is used (based on key)
 //!     .as_jwe(
 //!         &CryptoAlgorithm::XC20P,
@@ -142,7 +142,7 @@
 //! let message = Message::new() // creating message
 //!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
 //!     .to(&["did::xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"]) // setting to
-//!     .set_body(TEST_DID) // packing in some payload
+//!     .body(TEST_DID) // packing in some payload
 //!     .as_jws(&SignatureAlgorithm::EdDsa)
 //!     .sign(SignatureAlgorithm::EdDsa.signer(), &sign_keypair.to_bytes()).unwrap();
 //!
@@ -178,7 +178,7 @@
 //!     // setting to
 //!     .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
 //!     // packing in some payload
-//!     .set_body(r#"{"foo":"bar"}"#)
+//!     .body(r#"{"foo":"bar"}"#)
 //!     // set JOSE header for XC20P algorithm
 //!     .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
 //!     // custom header
@@ -271,7 +271,7 @@
 //! let message = Message::new() // creating message
 //!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
 //!     .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
-//!     .set_body(TEST_DID) // packing in some payload
+//!     .body(TEST_DID) // packing in some payload
 //!     .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
 //!     .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
 //!     .add_header_field("another_key".into(), "another_value".into()) // another custom header
@@ -341,7 +341,7 @@ assert!(received_second.is_ok());
 )]
 //! ## Pluggable cryptography
 //!
-//! In order to use your own implementation[s] of message crypto and/or signature algorithms implement these trait[s]:
+//! In order to use your own implementation(s) of message crypto and/or signature algorithms implement these trait(s):
 //!
 //! [`didcomm_rs::crypto::Cypher`][crypter]
 //!
@@ -410,7 +410,7 @@ assert!(received_second.is_ok());
 //! let message = Message::new() // creating message
 //!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
 //!     .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
-//!     .set_body(&body); // packing in some payload
+//!     .body(&body); // packing in some payload
 //! let received_typed_body = DesiredShape::shape(&message).unwrap(); // Where m = Message
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,407 @@
+//! Rust implementation of DIDComm v2 [spec](https://identity.foundation/didcomm-messaging/spec)
+//!
+//! ![tests](https://github.com/decentralized-identity/didcomm-rs/workflows/tests/badge.svg)
+//!
+//! ## License
+//!
+//! [Apache-2.0](LICENSE.md)
+//!
+//! ## Examples of usage
+//!
+//! ### 1. Prepare raw message for send and receive
+//!
+//! #### GoTo: [full test][send_receive_raw]
+//!
+//! ```rust
+//! # use didcomm_rs::Message;
+//! # const TEST_DID: &'static str = r###"{
+//! #     "@context": "https://www.w3.org/ns/did/v1",
+//! #     "id": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #     "verificationMethod": [
+//! #         {
+//! #             "id": "#DDMt6ythjG9pyuKcyFYHPC62gw6KjL8EdouCuNRm0GbU",
+//! #             "type": "Ed25519VerificationKey2018",
+//! #             "controller": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #             "publicKeyBase64": "DMt6ythjG9pyuKcyFYHPC62gw6KjL8EdouCuNRm0GbU="
+//! #         },
+//! #         {
+//! #             "id": "#CpPUgqlFBYtyXuCe6t8tXqeKo_wisONT9OzX-tRWNuGA",
+//! #             "type": "X25519KeyAgreementKey2019",
+//! #             "controller": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #             "publicKeyBase64": "pPUgqlFBYtyXuCe6t8tXqeKo_wisONT9OzX-tRWNuGA="
+//! #         }
+//! #     ]
+//! # }"###;
+//! // Message construction
+//! let m = Message::new()
+//!     // setting `from` header (sender) - Optional
+//!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_")
+//!     // setting `to` header (recipients) - Optional
+//!     .to(&[
+//!         "did::xyz:34r3cu403hnth03r49g03",
+//!         "did:xyz:30489jnutnjqhiu0uh540u8hunoe",
+//!     ])
+//!     // populating body with some data - `Vec<bytes>`
+//!     .set_body(TEST_DID);
+//!
+//! // Serialize message into JWM json (SENDER action)
+//! let ready_to_send = m.clone().as_raw_json().unwrap();
+//!
+//! // ... transport is happening here ...
+//!
+//! // On receival deserialize from json into Message (RECEIVER action)
+//! // Error handling recommended here
+//!
+//! let received = Message::receive(&ready_to_send, None, None, None);
+//! ```
+//!
+//! ### 2. Prepare JWE message for direct send
+//!
+//! #### GoTo: [full test][send_receive_encrypted_xc20p_json_test]
+//!
+//! ```rust
+//! # use didcomm_rs::{crypto::CryptoAlgorithm, Message};
+//! # use utilities::{get_keypair_set, KeyPairSet};
+//! # const TEST_DID: &'static str = r###"{
+//! #     "@context": "https://www.w3.org/ns/did/v1",
+//! #     "id": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #     "verificationMethod": [
+//! #         {
+//! #             "id": "#DDMt6ythjG9pyuKcyFYHPC62gw6KjL8EdouCuNRm0GbU",
+//! #             "type": "Ed25519VerificationKey2018",
+//! #             "controller": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #             "publicKeyBase64": "DMt6ythjG9pyuKcyFYHPC62gw6KjL8EdouCuNRm0GbU="
+//! #         },
+//! #         {
+//! #             "id": "#CpPUgqlFBYtyXuCe6t8tXqeKo_wisONT9OzX-tRWNuGA",
+//! #             "type": "X25519KeyAgreementKey2019",
+//! #             "controller": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #             "publicKeyBase64": "pPUgqlFBYtyXuCe6t8tXqeKo_wisONT9OzX-tRWNuGA="
+//! #         }
+//! #     ]
+//! # }"###;
+//! # let KeyPairSet { bobs_public, .. } = get_keypair_set();
+//! // sender key as bytes
+//! let ek = [130, 110, 93, 113, 105, 127, 4, 210, 65, 234, 112, 90, 150, 120, 189, 252, 212, 165, 30, 209, 194, 213, 81, 38, 250, 187, 216, 14, 246, 250, 166, 92];
+//!
+//! // Message construction
+//! let message = Message::new()
+//!     .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
+//!     .to(&[
+//!         "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
+//!         "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
+//!     ])
+//!     // packing in some payload (can be anything really)
+//!     .set_body(TEST_DID)
+//!     // decide which [Algorithm](crypto::encryptor::CryptoAlgorithm) is used (based on key)
+//!     .as_jwe(
+//!         &CryptoAlgorithm::XC20P,
+//!         Some(&bobs_public),
+//!     )
+//!     // add some custom app/protocol related headers to didcomm header portion
+//!     // these are not included into JOSE header
+//!     .add_header_field("my_custom_key".into(), "my_custom_value".into())
+//!     .add_header_field("another_key".into(), "another_value".into())
+//!     // set `kid` property
+//!     .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#);
+//!
+//! // receiver public key is automatically resolved
+//! let ready_to_send = message.seal(&ek, Some(&bobs_public)).unwrap();
+//!
+//! //... transport is happening here ...
+//! ```
+//!
+//! ### 3. Prepare JWS message -> send -> receive
+//!
+//! * Here `Message` is signed but not encrypted.
+//! * In such scenarios explicit use of `.sign(...)` and `Message::verify(...)` required.
+//!
+//! ```rust
+//! # use didcomm_rs::{crypto::{Signer, SignatureAlgorithm}, Message};
+//! # use k256::elliptic_curve::rand_core::OsRng;
+//! # const TEST_DID: &'static str = r###"{
+//! #     "@context": "https://www.w3.org/ns/did/v1",
+//! #     "id": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #     "verificationMethod": [
+//! #         {
+//! #             "id": "#DDMt6ythjG9pyuKcyFYHPC62gw6KjL8EdouCuNRm0GbU",
+//! #             "type": "Ed25519VerificationKey2018",
+//! #             "controller": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #             "publicKeyBase64": "DMt6ythjG9pyuKcyFYHPC62gw6KjL8EdouCuNRm0GbU="
+//! #         },
+//! #         {
+//! #             "id": "#CpPUgqlFBYtyXuCe6t8tXqeKo_wisONT9OzX-tRWNuGA",
+//! #             "type": "X25519KeyAgreementKey2019",
+//! #             "controller": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #             "publicKeyBase64": "pPUgqlFBYtyXuCe6t8tXqeKo_wisONT9OzX-tRWNuGA="
+//! #         }
+//! #     ]
+//! # }"###;
+//! # let sign_keypair = ed25519_dalek::Keypair::generate(&mut OsRng);
+//! // Message construction an JWS wrapping
+//! let message = Message::new() // creating message
+//!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
+//!     .to(&["did::xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"]) // setting to
+//!     .set_body(TEST_DID) // packing in some payload
+//!     .as_jws(&SignatureAlgorithm::EdDsa)
+//!     .sign(SignatureAlgorithm::EdDsa.signer(), &sign_keypair.to_bytes()).unwrap();
+//!
+//! //... transport is happening here ...
+//!
+//! // Receiving JWS
+//! let received = Message::verify(&message.as_bytes(), &sign_keypair.public.to_bytes());
+//! ```
+//!
+//! ### 4. Prepare JWE message to be mediated -> mediate -> receive
+//!
+//! * Message should be encrypted by destination key first in `.routed_by()` method call using key for the recipient.
+//! * Next it should be encrypted by mediator key in `.seal()` method call - this can be done multiple times - once for each mediator in chain but should be strictly sequential to match mediators sequence in the chain.
+//! * Method call `.seal()` **MUST** be preceded by  `.as_jwe(CryptoAlgorithm)` as mediators may use different algorithms and key types than destination and this is not automatically predicted or populated.
+//! * Keys used for encryption should be used in reverse order - final destination - last mediator - second to last mediator - etc. Onion style.
+//!
+//! #### GoTo: [full test][send_receive_mediated_encrypted_xc20p_json_test]
+//!
+//! ```ignore
+//!  // Message construction
+//! let message = Message::new()
+//!     // setting from
+//!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_")
+//!     // setting to
+//!     .to(&["did:xyz:34r3cu403hnth03r49g03", "did:xyz:30489jnutnjqhiu0uh540u8hunoe"])
+//!     // packing in some payload
+//!     .set_body(some_payload.as_bytes())
+//!     // set JOSE header for XC20P algorithm
+//!     .as_jwe(CryptoAlgorithm::XC20P)
+//!     // custom header
+//!     .add_header_field("my_custom_key".into(), "my_custom_value".into())
+//!     // another custom header
+//!     .add_header_field("another_key".into(), "another_value".into())
+//!     // set kid header
+//!     .kid(String::from(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#))
+//!     // here we use destination key to bob and `to` header of mediator -
+//!     //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
+//!     // `ek_to_bob` - destination targeted encryption key
+//!     .routed_by(ek_to_bob.as_bytes(), vec!("did:mediator:suetcpl23pt23rp2teu995t98u"));
+//!
+//! // Message envelope to mediator
+//! let ready_to_send = message
+//!     .unwrap() // **ERROR HANDLE** here is recommended
+//!     .as_jwe(CryptoAlgorithm::XC20P) // here this method call is crucial as mediator and end receiver may use different algorithms.
+//!     // `ek_to_mediator` - mediator targeted encryption key
+//!     .seal(ek_to_mediator.as_bytes()); // this would've failed without previous method call.
+//!
+//! //... transport to mediator is happening here ...
+//!
+//! // Received by mediator
+//! // `rk_mediator` - key to decrypt mediated message
+//! let received_mediated = Message::receive(&ready_to_send.unwrap(), Some(rk_mediator.as_bytes()));
+//!
+//! //... transport to destination is happening here ...
+//!
+//! // Received by Bob
+//! // `rk_bob` - key to decrypt final message
+//! let received_bob = Message::receive(&String::from_utf8_lossy(&received_mediated.unwrap().get_body()?.as_ref()), Some(rk_bob.as_bytes()));
+//! ```
+//!
+
+//! ### 5. Prepare JWS envelope wrapped into JWE -> sign -> pack -> receive
+//!
+//! * JWS header is set automatically based on signing algorithm type.
+//! * Message forming and encryption happens in same way as in other JWE examples.
+//! * ED25519-dalek signature is used in this example with keypair for signing and public key for verification.
+//!
+//! #### GoTo: [full test][send_receive_direct_signed_and_encrypted_xc20p_test]
+//!
+//! ```rust
+//! # use didcomm_rs::{crypto::{CryptoAlgorithm, Signer, SignatureAlgorithm}, Message};
+//! # use k256::elliptic_curve::rand_core::OsRng;
+//! # use utilities::{get_keypair_set, KeyPairSet};
+//! # const TEST_DID: &'static str = r###"{
+//! #     "@context": "https://www.w3.org/ns/did/v1",
+//! #     "id": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #     "verificationMethod": [
+//! #         {
+//! #             "id": "#DDMt6ythjG9pyuKcyFYHPC62gw6KjL8EdouCuNRm0GbU",
+//! #             "type": "Ed25519VerificationKey2018",
+//! #             "controller": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #             "publicKeyBase64": "DMt6ythjG9pyuKcyFYHPC62gw6KjL8EdouCuNRm0GbU="
+//! #         },
+//! #         {
+//! #             "id": "#CpPUgqlFBYtyXuCe6t8tXqeKo_wisONT9OzX-tRWNuGA",
+//! #             "type": "X25519KeyAgreementKey2019",
+//! #             "controller": "did:jun:ErJ3ahRB-zmOvTp0QmcJQfLq3hCAHBpXmoYLeHK8fHhw",
+//! #             "publicKeyBase64": "pPUgqlFBYtyXuCe6t8tXqeKo_wisONT9OzX-tRWNuGA="
+//! #         }
+//! #     ]
+//! # }"###;
+//! let KeyPairSet {
+//!     alice_public,
+//!     alice_private,
+//!     bobs_private,
+//!     bobs_public,
+//!     ..
+//! } = get_keypair_set();
+//! # let sign_keypair = ed25519_dalek::Keypair::generate(&mut OsRng);
+//! // Message construction
+//! let message = Message::new() // creating message
+//!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
+//!     .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
+//!     .set_body(TEST_DID) // packing in some payload
+//!     .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
+//!     .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
+//!     .add_header_field("another_key".into(), "another_value".into()) // another custom header
+//!     .kid(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#); // set kid header
+//!
+//! // Send as signed and encrypted JWS wrapped into JWE
+//! let ready_to_send = message.seal_signed(
+//!     &alice_private,
+//!     &sign_keypair.to_bytes(),
+//!     SignatureAlgorithm::EdDsa,
+//!     Some(&bobs_public),
+//! ).unwrap();
+//!
+//! //... transport to destination is happening here ...
+//!
+//! //Receive - same method to receive for JWE or JWS wrapped into JWE but with pub verifying key
+//! let received = Message::receive(
+//!     &ready_to_send,
+//!     Some(&bobs_private),
+//!     Some(&alice_public),
+//!     None,
+//! ); // and now we parse received
+//! ```
+//!
+//! ### 6. Multiple receivers static key wrap per recipient with shared secret
+//!
+//! * ! Works with `resolve` feature only - requires resolution of public keys for each recipient for shared secret generation.
+//! * Static key generated randomly in the background (`to` field has >1 recipient).
+//!
+//! #### GoTo: [full test][send_receive_didkey_test]
+//!
+#![cfg_attr(
+    feature = "resolve",
+    doc = r##"
+```rust
+# use didcomm_rs::{crypto::{CryptoAlgorithm}, Message};
+# use utilities::{get_keypair_set, KeyPairSet};
+# let KeyPairSet {
+#     alice_private,
+#     bobs_private,
+#     mediators_private: clarice_private,
+#     ..
+# } = get_keypair_set();
+// Creating message with multiple recipients.
+let m = Message::new()
+    .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
+    .to(&[
+        "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
+        "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
+    ])
+    .as_jwe(&CryptoAlgorithm::XC20P, None);
+
+let jwe = m.seal(&alice_private, None);
+// Packing was ok?
+assert!(jwe.is_ok());
+
+let jwe = jwe.unwrap();
+
+// Each of the recipients receive it in same way as before (direct with single receiver)
+let received_first = Message::receive(&jwe, Some(&bobs_private), None, None);
+let received_second = Message::receive(&jwe, Some(&clarice_private), None, None);
+
+// All good without any extra inputs
+assert!(received_first.is_ok());
+assert!(received_second.is_ok());
+```"##
+)]
+//! ## Pluggable cryptography
+//!
+//! In order to use your own implementation[s] of message crypto and/or signature algorithms implement these trait[s]:
+//!
+//! [`didcomm_rs::crypto::Cypher`][crypter]
+//!
+//! [`didcomm_rs::crypto::Signer`][signer]
+//!
+//! Don't use `default` feature - might change in future.
+//!
+//! When implemented - use them instead of `CryptoAlgorithm` and `SignatureAlgorithm` from examples above.
+//!
+//! ## Strongly typed Message payload (body)
+//!
+//! ### GoTo: [full test][shape_desired_test]
+//!
+//! In most cases application implementation would prefer to have strongly typed body of the message instead of raw `Vec<u8>`.
+//! For this scenario `Shape` trait should be implemented for target type.
+//!
+//! * First, let's define our target type. JSON in this example.
+//!
+//! ```rust
+//! # use serde::{Deserialize, Serialize};
+//! #[derive(Serialize, Deserialize, PartialEq, Debug)]
+//! struct DesiredShape {
+//!     num_field: usize,
+//!     string_field: String,
+//! }
+//! ```
+//!
+//! * Next, implement `Shape` trait for it
+//!
+//! ```rust
+//! # use didcomm_rs::{Error, Message, Shape};
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Serialize, Deserialize, PartialEq, Debug)]
+//! # struct DesiredShape {
+//! #     num_field: usize,
+//! #     string_field: String,
+//! # }
+//! impl Shape for DesiredShape {
+//!     type Err = Error;
+//!     fn shape(m: &Message) -> Result<DesiredShape, Error> {
+//!         serde_json::from_str(&m.get_body().unwrap())
+//!             .map_err(|e| Error::SerdeError(e))
+//!     }
+//! }
+//! ```
+//!
+//! * Now we can call `shape()` on our `Message` and shape in in.
+//! * In this example we expect JSON payload and use it's Deserializer to get our data, but your implementation can work with any serialization.
+//!
+//! ```rust
+//! # use didcomm_rs::{Error, Message, Shape};
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Serialize, Deserialize, PartialEq, Debug)]
+//! # struct DesiredShape {
+//! #     num_field: usize,
+//! #     string_field: String,
+//! # }
+//! # impl Shape for DesiredShape {
+//! #     type Err = Error;
+//! #     fn shape(m: &Message) -> Result<DesiredShape, Error> {
+//! #         serde_json::from_str(&m.get_body().unwrap())
+//! #             .map_err(|e| Error::SerdeError(e))
+//! #     }
+//! # }
+//! let body = r#"{"num_field":123,"string_field":"foobar"}"#.to_string();
+//! let message = Message::new() // creating message
+//!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
+//!     .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
+//!     .set_body(&body); // packing in some payload
+//! let received_typed_body = DesiredShape::shape(&message).unwrap(); // Where m = Message
+//! ```
+//!
+//! ## Disclaimer
+//!
+//! This is a sample implementation of the DIDComm V2 spec. The DIDComm V2 spec is still actively being developed by the DIDComm WG in the DIF and therefore subject to change.
+//!
+//! <!-- Collect links to line numbers here to be able to maintain them easier -->
+//! [crypter]: https://github.com/evannetwork/didcomm-rs/blob/master/src/crypto/mod.rs#L30
+//! [send_receive_raw]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L16
+//! [send_receive_encrypted_xc20p_json_test]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L42
+//! [send_receive_mediated_encrypted_xc20p_json_test]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L84
+//! [send_receive_direct_signed_and_encrypted_xc20p_test]: https://github.com/evannetwork/didcomm-rs/blob/master/tests/send_receive.rs#L164
+//! [send_receive_didkey_test]: https://github.com/evannetwork/didcomm-rs/blob/master/src/messages/message.rs#L482
+//! [shape_desired_test]: https://github.com/evannetwork/didcomm-rs/blob/main/tests/shape.rs#L21
+//! [signer]: https://github.com/evannetwork/didcomm-rs/blob/master/src/crypto/mod.rs#L39
 extern crate env_logger;
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@
 //!     // set `kid` property
 //!     .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#);
 //!
-//! // receiver public key is automatically resolved
+//! // recipient public key is automatically resolved
 //! let ready_to_send = message.seal(&ek, Some(&bobs_public)).unwrap();
 //!
 //! //... transport is happening here ...
@@ -296,7 +296,7 @@
 //! ); // and now we parse received
 //! ```
 //!
-//! ### 6. Multiple receivers static key wrap per recipient with shared secret
+//! ### 6. Multiple recipients static key wrap per recipient with shared secret
 //!
 //! * ! Works with `resolve` feature only - requires resolution of public keys for each recipient for shared secret generation.
 //! * Static key generated randomly in the background (`to` field has >1 recipient).
@@ -330,7 +330,7 @@ assert!(jwe.is_ok());
 
 let jwe = jwe.unwrap();
 
-// Each of the recipients receive it in same way as before (direct with single receiver)
+// Each of the recipients receive it in same way as before (direct with single recipient)
 let received_first = Message::receive(&jwe, Some(&bobs_private), None, None);
 let received_second = Message::receive(&jwe, Some(&clarice_private), None, None);
 

--- a/src/messages/didurl.rs
+++ b/src/messages/didurl.rs
@@ -2,6 +2,7 @@ use std::{str::FromStr, string::ToString};
 
 use crate::Error;
 
+/// DID URL string
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DidUrl(pub String);
 

--- a/src/messages/headers/headers.rs
+++ b/src/messages/headers/headers.rs
@@ -10,6 +10,8 @@ use crate::{
     PriorClaims,
 };
 
+/// Collection of DIDComm message specific headers, will be flattened into DIDComm plain message
+/// according to [spec](https://datatracker.ietf.org/doc/html/draft-looker-jwm-01#section-4).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct DidCommHeader {
     pub id: String,

--- a/src/messages/headers/jwk.rs
+++ b/src/messages/headers/jwk.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+/// Encryption public key
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
 pub struct Epk {
     pub kty: String,

--- a/src/messages/headers/prior_claims.rs
+++ b/src/messages/headers/prior_claims.rs
@@ -1,5 +1,6 @@
 use crate::Error;
 
+/// header used for [DID rotation](https://identity.foundation/didcomm-messaging/spec/#did-rotation)
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct PriorClaims {
     sub: String,

--- a/src/messages/helpers/encryption.rs
+++ b/src/messages/helpers/encryption.rs
@@ -37,12 +37,12 @@ pub(crate) fn decrypt_cek(
 ) -> Result<Vec<u8>, Error> {
     trace!("decrypting per-recipient JWE value");
     let alg = jwe
-        .alg()
+        .get_alg()
         .ok_or_else(|| Error::Generic("missing encryption 'alg' in header".to_string()))?;
     trace!("using algorithm {}", &alg);
 
     let skid = jwe
-        .skid()
+        .get_skid()
         .ok_or_else(|| Error::Generic("missing 'skid' in header".to_string()))?;
 
     // zE (temporary secret)

--- a/src/messages/helpers/encryption.rs
+++ b/src/messages/helpers/encryption.rs
@@ -20,15 +20,15 @@ use crate::{Error, Jwe, Jwk, JwmHeader, KeyAlgorithm, Message, Recipient};
 
 /// Decrypts the content encryption key with a key encryption key.
 ///
-/// # Parameters
+/// # Arguments
 ///
-/// `jwe` - jwe to decrypt content encryption key for
+/// * `jwe` - jwe to decrypt content encryption key for
 ///
-/// `sk` - receivers private key
+/// * `sk` - receivers private key
 ///
-/// `recipient` - recipient data from JWE
+/// * `recipient` - recipient data from JWE
 ///
-/// `recipient_public_key` - can be provided if key should not be resolved via recipients DID
+/// * `recipient_public_key` - can be provided if key should not be resolved via recipients DID
 pub(crate) fn decrypt_cek(
     jwe: &Jwe,
     sk: &[u8],
@@ -111,15 +111,17 @@ pub(crate) fn decrypt_cek(
 
 /// Encrypts the content encryption key with a key encryption key.
 ///
-/// # Parameters
+/// # Arguments
 ///
-/// `sk` - senders private key
+/// * `message` - message the content encryption key should be encrypted for
 ///
-/// `dest` - receiver to encrypt cek for
+/// * `sk` - senders private key
 ///
-/// `cek` - key used to encrypt content with, will be encrypted per recipient
+/// * `dest` - receiver to encrypt cek for
 ///
-/// `recipient_public_key` - can be provided if key should not be resolved via recipients DID
+/// * `cek` - key used to encrypt content with, will be encrypted per recipient
+///
+/// * `recipient_public_key` - can be provided if key should not be resolved via recipients DID
 pub(crate) fn encrypt_cek(
     message: &Message,
     sk: &[u8],
@@ -228,11 +230,11 @@ pub(crate) fn get_crypter_from_header(header: &JwmHeader) -> Result<CryptoAlgori
 /// Use given key from `signing_sender_public_key` or if `None`, use key from "kid".
 /// `kid` is currently "resolved" by hex-decoding it and using it as the public key.
 ///
-/// # Parameters
+/// # Arguments
 ///
-/// `signing_sender_public_key` - optional senders public to verify signature
+/// * `signing_sender_public_key` - optional senders public to verify signature
 ///
-/// `kid` - key reference to senders public key to verify signature
+/// * `kid` - key reference to senders public key to verify signature
 pub(crate) fn get_signing_sender_public_key(
     signing_sender_public_key: Option<&[u8]>,
     kid: Option<&String>,
@@ -282,17 +284,17 @@ fn concat_kdf(
 
 /// Creates a key used to encrypt/decrypt keys (key encryption key).
 ///
-/// # Parameters
+/// # Arguments
 ///
-/// `did` - receiver of a message (during encryption) or sender of a message (during decryption)
+/// * `did` - receiver of a message (during encryption) or sender of a message (during decryption)
 ///
-/// `sk` - senders private key (encryption) or receivers private key (decryption)
+/// * `sk` - senders private key (encryption) or receivers private key (decryption)
 ///
-/// `ze` - temporary secret zE
+/// * `ze` - temporary secret zE
 ///
-/// `alg` - encryption algorithm used
+/// * `alg` - encryption algorithm used
 ///
-/// `recipient_public_key` - can be provided if key should not be resolved via recipients DID
+/// * `recipient_public_key` - can be provided if key should not be resolved via recipients DID
 fn generate_kek(
     did: &str,
     sk: &[u8],

--- a/src/messages/helpers/encryption.rs
+++ b/src/messages/helpers/encryption.rs
@@ -24,7 +24,7 @@ use crate::{Error, Jwe, Jwk, JwmHeader, KeyAlgorithm, Message, Recipient};
 ///
 /// * `jwe` - jwe to decrypt content encryption key for
 ///
-/// * `sk` - receivers private key
+/// * `sk` - recipients private key
 ///
 /// * `recipient` - recipient data from JWE
 ///
@@ -117,7 +117,7 @@ pub(crate) fn decrypt_cek(
 ///
 /// * `sk` - senders private key
 ///
-/// * `dest` - receiver to encrypt cek for
+/// * `dest` - recipient to encrypt cek for
 ///
 /// * `cek` - key used to encrypt content with, will be encrypted per recipient
 ///
@@ -288,9 +288,9 @@ fn concat_kdf(
 ///
 /// # Arguments
 ///
-/// * `did` - receiver of a message (during encryption) or sender of a message (during decryption)
+/// * `did` - recipient of a message (during encryption) or sender of a message (during decryption)
 ///
-/// * `sk` - senders private key (encryption) or receivers private key (decryption)
+/// * `sk` - senders private key (encryption) or recipient private key (decryption)
 ///
 /// * `ze` - temporary secret zE
 ///

--- a/src/messages/helpers/encryption.rs
+++ b/src/messages/helpers/encryption.rs
@@ -8,7 +8,7 @@ use chacha20poly1305::{
     XNonce,
 };
 #[cfg(feature = "resolve")]
-pub use ddoresolver_rs::*;
+use ddoresolver_rs::*;
 use k256::elliptic_curve::rand_core;
 use rand::{prelude::SliceRandom, Rng};
 use sha2::{Digest, Sha256};

--- a/src/messages/helpers/getters.rs
+++ b/src/messages/helpers/getters.rs
@@ -1,6 +1,16 @@
 macro_rules! create_fallback_getter {
     ($primary_field:ident, $fallback_field:ident, $field_name:ident, $field_type:ident) => {
         paste::item! {
+            #[doc = concat!(
+                "Gets `",
+                stringify!($field_name),
+                "` header value from either `",
+                stringify!($primary_field),
+                "` or from `",
+                stringify!($fallback_field),
+                "`.\n\n",
+                "Will default to `None` if not set in any of them."
+            )]
             pub fn [< get_ $field_name >](&self) -> Option<$field_type> {
                 if let Some(value) = &self.$primary_field {
                     if let Some(value) = &value.$field_name {

--- a/src/messages/helpers/getters.rs
+++ b/src/messages/helpers/getters.rs
@@ -1,0 +1,20 @@
+macro_rules! create_fallback_getter {
+    ($primary_field:ident, $fallback_field:ident, $field_name:ident, $field_type:ident) => {
+        paste::item! {
+            pub fn [< get_ $field_name >](&self) -> Option<$field_type> {
+                if let Some(value) = &self.$primary_field {
+                    if let Some(value) = &value.$field_name {
+                        return Some(value.clone());
+                    }
+                }
+                if let Some(value) = &self.$fallback_field {
+                    if let Some(value) = &value.$field_name {
+                        return Some(value.clone());
+                    }
+                }
+                None
+            }
+        }
+    };
+}
+pub(crate) use create_fallback_getter;

--- a/src/messages/helpers/getters.rs
+++ b/src/messages/helpers/getters.rs
@@ -1,3 +1,20 @@
+/// Generates a getter for fetching the first not `None` value sub-property from one of two
+/// optional fields.
+///
+/// Used to look if header value `field_name` is present in at least one of two headers which
+/// themselves are optional as well.
+///
+/// Returns `None` if both fields are unset.
+///
+/// # Arguments
+///
+/// * `primary_field` - first optional field of `self` to check for a value
+///
+/// * `fallback_field` - second optional field of `self to check for a value
+///
+/// * `field_name` - name of field
+///
+/// * `field_type` - type of field
 macro_rules! create_fallback_getter {
     ($primary_field:ident, $fallback_field:ident, $field_name:ident, $field_type:ident) => {
         paste::item! {

--- a/src/messages/helpers/mod.rs
+++ b/src/messages/helpers/mod.rs
@@ -1,7 +1,9 @@
 mod encryption;
+mod getters;
 mod receive;
 mod serialization;
 
 pub(crate) use encryption::*;
+pub(crate) use getters::*;
 pub(crate) use receive::*;
 pub(crate) use serialization::*;

--- a/src/messages/helpers/receive.rs
+++ b/src/messages/helpers/receive.rs
@@ -52,7 +52,7 @@ pub(crate) fn receive_jwe(
     encryption_sender_public_key: Option<&[u8]>,
 ) -> Result<String, Error> {
     let jwe: Jwe = serde_json::from_str(incoming)?;
-    let alg = &jwe.alg().ok_or(Error::JweParseError)?;
+    let alg = &jwe.get_alg().ok_or(Error::JweParseError)?;
 
     // get public key from input or from senders DID document
     let sender_public_key = match encryption_sender_public_key {
@@ -61,7 +61,7 @@ pub(crate) fn receive_jwe(
             #[cfg(feature = "resolve")]
             {
                 let skid = &jwe
-                    .skid()
+                    .get_skid()
                     .ok_or_else(|| Error::Generic("skid missing".to_string()))?;
                 let document = ddoresolver_rs::resolve_any(skid).ok_or(Error::DidResolveFailed)?;
                 document
@@ -147,12 +147,12 @@ pub(crate) fn receive_jws(
         let incoming_string = incoming.to_string();
         let to_verify = incoming_string.as_bytes();
         for signature_value in signatures_values_to_verify {
-            if signature_value.alg().is_none() {
+            if signature_value.get_alg().is_none() {
                 continue;
             }
             let key = get_signing_sender_public_key(
                 signing_sender_public_key,
-                signature_value.kid().as_ref(),
+                signature_value.get_kid().as_ref(),
             )?;
             if let Ok(message_result) = Message::verify(&to_verify, &key) {
                 message_verified = Some(message_result);

--- a/src/messages/helpers/receive.rs
+++ b/src/messages/helpers/receive.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 
 use arrayref::array_ref;
 #[cfg(feature = "resolve")]
-pub use ddoresolver_rs::*;
+use ddoresolver_rs::*;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use x25519_dalek::{PublicKey, StaticSecret};

--- a/src/messages/helpers/receive.rs
+++ b/src/messages/helpers/receive.rs
@@ -117,12 +117,12 @@ pub(crate) fn receive_jwe(
             }
         }
         if !key.is_empty() {
-            m = Message::decrypt(incoming.as_bytes(), a.decryptor(), &key)?;
+            m = Message::decrypt(incoming.as_bytes(), a.decrypter(), &key)?;
         } else {
             return Err(Error::JweParseError);
         }
     } else {
-        m = Message::decrypt(incoming.as_bytes(), a.decryptor(), shared.as_bytes())?;
+        m = Message::decrypt(incoming.as_bytes(), a.decrypter(), shared.as_bytes())?;
     }
 
     Ok(serde_json::to_string(&m)?)

--- a/src/messages/helpers/serialization.rs
+++ b/src/messages/helpers/serialization.rs
@@ -1,4 +1,5 @@
-// see https://users.rust-lang.org/t/serialize-a-vec-u8-to-json-as-base64/57781/2
+/// (de)serialzies between `Vec<u8>` and base64 `String`
+/// see `<https://users.rust-lang.org/t/serialize-a-vec-u8-to-json-as-base64/57781/2>`
 pub(crate) mod serialization_base64_buffer {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -13,7 +14,8 @@ pub(crate) mod serialization_base64_buffer {
     }
 }
 
-// see https://users.rust-lang.org/t/serialize-a-vec-u8-to-json-as-base64/57781/2
+/// (de)serialzies between `Option<JwmHeader>` and base64 `String`
+/// see `<https://users.rust-lang.org/t/serialize-a-vec-u8-to-json-as-base64/57781/2>`
 pub(crate) mod serialization_base64_jwm_header {
     use std::str::from_utf8;
 

--- a/src/messages/jwe.rs
+++ b/src/messages/jwe.rs
@@ -12,11 +12,13 @@ use crate::{
 /// Can be serialized to JSON or Compact representations and from same.
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct Jwe {
+    /// integrity protected header elements
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "serialization_base64_jwm_header")]
     pub protected: Option<JwmHeader>,
 
+    /// header elements that are not integrity protected
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unprotected: Option<JwmHeader>,
 
@@ -31,10 +33,13 @@ pub struct Jwe {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recipients: Option<Vec<Recipient>>,
 
+    /// Encrypted data of JWE as base64 encoded String
     ciphertext: String,
 
+    /// Initial vector for encryption as base64 encoded String
     iv: String,
 
+    /// base64 encoded JWE authentication tag
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tag: Option<String>,
 }
@@ -80,6 +85,7 @@ impl Jwe {
         }
     }
 
+    /// Generate new random IV as String
     pub fn generate_iv() -> String {
         let mut rng = rand::thread_rng();
         let mut a = rng.gen::<[u8; 24]>().to_vec();
@@ -87,7 +93,7 @@ impl Jwe {
         encode(&a)
     }
 
-    /// `iv` getter
+    /// Gets `iv` as byte array.
     pub fn get_iv(&self) -> impl AsRef<[u8]> {
         decode(&self.iv).unwrap()
     }

--- a/src/messages/jwe.rs
+++ b/src/messages/jwe.rs
@@ -1,25 +1,12 @@
 use base64_url::{decode, encode};
 use rand::{prelude::SliceRandom, Rng};
 
-use crate::{messages::helpers::serialization_base64_jwm_header, Jwk, JwmHeader, Recipient};
-
-macro_rules! create_getter {
-    ($field_name:ident, $field_type:ident) => {
-        pub fn $field_name(&self) -> Option<$field_type> {
-            if let Some(protected) = &self.protected {
-                if let Some(value) = &protected.$field_name {
-                    return Some(value.clone());
-                }
-            }
-            if let Some(unprotected) = &self.unprotected {
-                if let Some(value) = &unprotected.$field_name {
-                    return Some(value.clone());
-                }
-            }
-            None
-        }
-    };
-}
+use crate::{
+    messages::helpers::{create_fallback_getter, serialization_base64_jwm_header},
+    Jwk,
+    JwmHeader,
+    Recipient,
+};
 
 /// JWE representation of `Message` with public header.
 /// Can be serialized to JSON or Compact representations and from same.
@@ -124,21 +111,21 @@ impl Jwe {
         })
     }
 
-    create_getter!(alg, String);
+    create_fallback_getter!(protected, unprotected, alg, String);
 
-    create_getter!(cty, String);
+    create_fallback_getter!(protected, unprotected, cty, String);
 
-    create_getter!(enc, String);
+    create_fallback_getter!(protected, unprotected, enc, String);
 
-    create_getter!(epk, Jwk);
+    create_fallback_getter!(protected, unprotected, epk, Jwk);
 
-    create_getter!(jku, String);
+    create_fallback_getter!(protected, unprotected, jku, String);
 
-    create_getter!(jwk, Jwk);
+    create_fallback_getter!(protected, unprotected, jwk, Jwk);
 
-    create_getter!(kid, String);
+    create_fallback_getter!(protected, unprotected, kid, String);
 
-    create_getter!(skid, String);
+    create_fallback_getter!(protected, unprotected, skid, String);
 }
 
 #[test]

--- a/src/messages/jwe.rs
+++ b/src/messages/jwe.rs
@@ -112,9 +112,9 @@ impl Jwe {
 
     /// Gets initial vector from option or creates a new one.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// `iv_input` - an option that may contain an initial vector
+    /// * `iv_input` - an option that may contain an initial vector
     fn ensure_iv(iv_input: Option<String>) -> String {
         iv_input.unwrap_or_else(|| {
             let mut rng = rand::thread_rng();

--- a/src/messages/jwe.rs
+++ b/src/messages/jwe.rs
@@ -87,28 +87,14 @@ impl Jwe {
         encode(&a)
     }
 
-    /// Getter for ciphered payload of JWE.
-    pub fn payload(&self) -> Vec<u8> {
-        decode(&self.ciphertext).unwrap()
-    }
-
     /// `iv` getter
     pub fn get_iv(&self) -> impl AsRef<[u8]> {
         decode(&self.iv).unwrap()
     }
 
-    /// Gets initial vector from option or creates a new one.
-    ///
-    /// # Arguments
-    ///
-    /// * `iv_input` - an option that may contain an initial vector
-    fn ensure_iv(iv_input: Option<String>) -> String {
-        iv_input.unwrap_or_else(|| {
-            let mut rng = rand::thread_rng();
-            let mut a = rng.gen::<[u8; 24]>().to_vec();
-            a.shuffle(&mut rng);
-            encode(&a)
-        })
+    /// Getter for ciphered payload of JWE.
+    pub fn get_payload(&self) -> Vec<u8> {
+        decode(&self.ciphertext).unwrap()
     }
 
     create_fallback_getter!(protected, unprotected, alg, String);
@@ -126,6 +112,20 @@ impl Jwe {
     create_fallback_getter!(protected, unprotected, kid, String);
 
     create_fallback_getter!(protected, unprotected, skid, String);
+
+    /// Gets initial vector from option or creates a new one.
+    ///
+    /// # Arguments
+    ///
+    /// * `iv_input` - an option that may contain an initial vector
+    fn ensure_iv(iv_input: Option<String>) -> String {
+        iv_input.unwrap_or_else(|| {
+            let mut rng = rand::thread_rng();
+            let mut a = rng.gen::<[u8; 24]>().to_vec();
+            a.shuffle(&mut rng);
+            encode(&a)
+        })
+    }
 }
 
 #[test]

--- a/src/messages/jws.rs
+++ b/src/messages/jws.rs
@@ -1,26 +1,9 @@
 use crate::{
+    helpers::create_fallback_getter,
     messages::helpers::{serialization_base64_buffer, serialization_base64_jwm_header},
     Jwk,
     JwmHeader,
 };
-
-macro_rules! create_getter {
-    ($field_name:ident, $field_type:ident) => {
-        pub fn $field_name(&self) -> Option<$field_type> {
-            if let Some(header) = &self.header {
-                if let Some(value) = &header.$field_name {
-                    return Some(value.clone());
-                }
-            }
-            if let Some(protected) = &self.protected {
-                if let Some(value) = &protected.$field_name {
-                    return Some(value.clone());
-                }
-            }
-            None
-        }
-    };
-}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Signature {
@@ -60,21 +43,21 @@ impl Signature {
         }
     }
 
-    create_getter!(alg, String);
+    create_fallback_getter!(header, protected, alg, String);
 
-    create_getter!(cty, String);
+    create_fallback_getter!(header, protected, cty, String);
 
-    create_getter!(enc, String);
+    create_fallback_getter!(header, protected, enc, String);
 
-    create_getter!(epk, Jwk);
+    create_fallback_getter!(header, protected, epk, Jwk);
 
-    create_getter!(jku, String);
+    create_fallback_getter!(header, protected, jku, String);
 
-    create_getter!(jwk, Jwk);
+    create_fallback_getter!(header, protected, jwk, Jwk);
 
-    create_getter!(kid, String);
+    create_fallback_getter!(header, protected, kid, String);
 
-    create_getter!(skid, String);
+    create_fallback_getter!(header, protected, skid, String);
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/messages/jws.rs
+++ b/src/messages/jws.rs
@@ -41,13 +41,13 @@ impl Signature {
     /// Creates a new `Signature` that can be used in JWS `signatures` property or
     /// as top-level (flattened) property in flattened JWS JSON serialization.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// `protected` - JWM header protected by signing
+    /// * `protected` - JWM header protected by signing
     ///
-    /// `header` - JWM header not protected by signing
+    /// * `header` - JWM header not protected by signing
     ///
-    /// `signature` - signature over JWS payload and protected header
+    /// * `signature` - signature over JWS payload and protected header
     pub fn new(
         protected: Option<JwmHeader>,
         header: Option<JwmHeader>,
@@ -97,11 +97,11 @@ impl Jws {
     /// Creates a new [general JWS](https://datatracker.ietf.org/doc/html/rfc7515#section-7.2.1)
     /// object with signature values per recipient.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// `payload` - payload with encoded data
+    /// * `payload` - payload with encoded data
     ///
-    /// `signatures` - signature values per recipient
+    /// * `signatures` - signature values per recipient
     pub fn new(payload: String, signatures: Vec<Signature>) -> Self {
         Jws {
             payload,
@@ -113,11 +113,11 @@ impl Jws {
     /// Creates a new [flattened JWS](https://datatracker.ietf.org/doc/html/rfc7515#section-7.2.2)
     /// object with signature information on JWS' top level.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// `payload` - payload with encoded data
+    /// * `payload` - payload with encoded data
     ///
-    /// `signatures` - signature value that is used on JWS top-level
+    /// * `signatures_value` - signature value that is used on JWS top-level
     pub fn new_flat(payload: String, signature_value: Signature) -> Self {
         Jws {
             payload,

--- a/src/messages/jws.rs
+++ b/src/messages/jws.rs
@@ -5,16 +5,24 @@ use crate::{
     JwmHeader,
 };
 
+/// Signature data for [JWS](https://datatracker.ietf.org/doc/html/rfc7515) envelopes.
+/// They can be used per recipient in [General JWS JSON](https://datatracker.ietf.org/doc/html/rfc7515#section-7.2.1),
+/// triggered by using [`.as_jws`][crate::Message::as_jws()] or as a single signature for the entire JWS in
+/// [Flattened JWS JSON](https://datatracker.ietf.org/doc/html/rfc7515#section-7.2.2), triggered by
+/// [`.as_flat_jws`][crate::Message::as_flat_jws()].
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Signature {
+    /// integrity protected header elements
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "serialization_base64_jwm_header")]
     pub protected: Option<JwmHeader>,
 
+    /// header elements that are not integrity protected
     #[serde(skip_serializing_if = "Option::is_none")]
     pub header: Option<JwmHeader>,
 
+    /// signature computed over protected header elements
     #[serde(default)]
     #[serde(with = "serialization_base64_buffer")]
     pub signature: Vec<u8>,
@@ -60,8 +68,11 @@ impl Signature {
     create_fallback_getter!(header, protected, skid, String);
 }
 
+/// A struct to generate and serialize [JWS](https://datatracker.ietf.org/doc/html/rfc7515)
+/// envelopes for DIDComm messages.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Jws {
+    /// base64 encoded payload of the JWS
     pub payload: String,
 
     /// Top-level signature for flat JWS JSON messages.

--- a/src/messages/mediated.rs
+++ b/src/messages/mediated.rs
@@ -11,8 +11,10 @@ pub struct Mediated {
 
 impl Mediated {
     /// Constructor with empty payload
-    /// # Parameters
-    /// *next - `DidUrl` of delivery target.
+    ///
+    /// # Arguments
+    ///
+    /// * `next` - `DidUrl` of delivery target.
     pub fn new(next: String) -> Self {
         Mediated {
             next,

--- a/src/messages/mediated.rs
+++ b/src/messages/mediated.rs
@@ -1,10 +1,13 @@
 use super::{Message, Shape};
 use crate::Error;
 
+/// Mediated Message value
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Mediated {
+    /// `DidUrl` of delivery target
     pub next: String,
 
+    /// "inner" message, that should be routed to target
     #[serde(rename = "payloads~attach")]
     pub payload: Vec<u8>,
 }

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -22,17 +22,19 @@ use crate::{
 };
 
 /// DIDComm message structure.
-/// [Specification](https://identity.foundation/didcomm-messaging/spec/#message-structure)
 ///
+/// `Message`s are used to construct new DIDComm messages, for usage see examples [here][`crate`].
+///
+/// [Specification](https://identity.foundation/didcomm-messaging/spec/#message-structure)
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Message {
     /// JOSE header, which is sent as public part with JWE.
     #[serde(flatten)]
-    pub jwm_header: JwmHeader,
+    pub(crate) jwm_header: JwmHeader,
 
     /// DIDComm headers part, sent as part of encrypted message in JWE.
     #[serde(flatten)]
-    pub didcomm_header: DidCommHeader,
+    pub(crate) didcomm_header: DidCommHeader,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) recipients: Option<Vec<Recipient>>,
@@ -45,12 +47,12 @@ pub struct Message {
     /// Flag that toggles JWE serialization to flat JSON.
     /// Not part of the serialized JSON and ignored when deserializing.
     #[serde(skip)]
-    pub serialize_flat_jwe: bool,
+    pub(crate) serialize_flat_jwe: bool,
 
     /// Flag that toggles JWS serialization to flat JSON.
     /// Not part of the serialized JSON and ignored when deserializing.
     #[serde(skip)]
-    pub serialize_flat_jws: bool,
+    pub(crate) serialize_flat_jws: bool,
 }
 
 // field getters/setters, default format handling
@@ -169,6 +171,19 @@ impl Message {
     /// Returns modified instance of `Self`.
     pub fn set_didcomm_header(mut self, h: DidCommHeader) -> Self {
         self.didcomm_header = h;
+        self
+    }
+
+    /// `&JwmCommHeader` getter.
+    pub fn get_jwm_header(&self) -> &JwmHeader {
+        &self.jwm_header
+    }
+
+    /// Setter of `jwm_header`.
+    /// Replaces existing one with provided by consuming both values.
+    /// Returns modified instance of `Self`.
+    pub fn set_jwm_header(mut self, h: JwmHeader) -> Self {
+        self.jwm_header = h;
         self
     }
 

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -47,6 +47,7 @@ pub struct Message {
     #[serde(flatten)]
     pub(crate) didcomm_header: DidCommHeader,
 
+    /// single recipient of JWE `recipients` collection as used in JWE
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) recipients: Option<Vec<Recipient>>,
 
@@ -153,8 +154,8 @@ impl Message {
         self
     }
 
-    /// Setter of the `body`
-    /// Helper method.
+    /// Setter of the `body`.
+    /// Note, that given text has to be a valid JSON string to be a valid body value.
     pub fn body(mut self, body: &str) -> Self {
         self.body = serde_json::from_str(body).unwrap();
         self
@@ -168,15 +169,13 @@ impl Message {
         self
     }
 
-    /// Setter of `from` header
-    /// Helper method.
+    /// Setter of `from` header.
     pub fn from(mut self, from: &str) -> Self {
         self.didcomm_header.from = Some(String::from(from));
         self
     }
 
-    /// Getter of the `body` as ref of bytes slice.
-    /// Helper method.
+    /// Getter of the `body` as String.
     pub fn get_body(&self) -> Result<String, Error> {
         Ok(serde_json::to_string(&self.body)?)
     }
@@ -216,7 +215,6 @@ impl Message {
     }
 
     // Setter of the `kid` header
-    // Helper method.
     pub fn kid(mut self, kid: &str) -> Self {
         match &mut self.jwm_header.kid {
             Some(h) => *h = kid.into(),
@@ -228,7 +226,6 @@ impl Message {
     }
 
     /// Setter of `m_type` @type header
-    /// Helper method.
     pub fn m_type(mut self, m_type: MessageType) -> Self {
         self.jwm_header.typ = m_type;
         self
@@ -251,7 +248,6 @@ impl Message {
     }
 
     /// Setter of `to` header
-    /// Helper method.
     pub fn to(mut self, to: &[&str]) -> Self {
         for s in to {
             self.didcomm_header.to.push(s.to_string());

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 #[cfg(feature = "resolve")]
-pub use ddoresolver_rs::*;
+use ddoresolver_rs::*;
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -279,14 +279,14 @@ impl Message {
     ///
     /// * `incoming` - serialized message as `Message`/`Jws`/`Jws`
     ///
-    /// * `encryption_receiver_private_key` - receivers private key, used to decrypt `kek` in JWE
+    /// * `encryption_recipient_private_key` - recipients private key, used to decrypt `kek` in JWE
     ///
     /// * `encryption_sender_public_key` - senders public key, used to decrypt `kek` in JWE
     ///
     /// * `signing_sender_public_key` - senders public key, the JWS envelope was signed with
     pub fn receive(
         incoming: &str,
-        encryption_receiver_private_key: Option<&[u8]>,
+        encryption_recipient_private_key: Option<&[u8]>,
         encryption_sender_public_key: Option<&[u8]>,
         signing_sender_public_key: Option<&[u8]>,
     ) -> Result<Self, Error> {
@@ -295,7 +295,7 @@ impl Message {
         if get_message_type(&current_message)? == MessageType::DidCommJwe {
             current_message = receive_jwe(
                 &current_message,
-                encryption_receiver_private_key,
+                encryption_recipient_private_key,
                 encryption_sender_public_key,
             )?;
         }
@@ -612,7 +612,7 @@ mod crypto_tests {
 
     #[test]
     #[cfg(feature = "resolve")]
-    fn send_receive_didkey_multiple_receivers_test() {
+    fn send_receive_didkey_multiple_recipients_test() {
         let m = Message::new()
             .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
             .to(&[

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -128,9 +128,11 @@ impl Message {
     }
 
     /// Sets times of creation as now and, optional, expires time.
-    /// # Parameters
+    ///
+    /// # Arguments
+    ///
     /// * `expires` - time in seconds since Unix Epoch when message is
-    /// considered to be invalid.
+    ///               considered to be invalid.
     pub fn timed(mut self, expires: Option<u64>) -> Self {
         self.didcomm_header.expires_time = expires;
         self.didcomm_header.created_time =
@@ -242,15 +244,15 @@ impl Message {
     /// Construct a message from received data.
     /// Raw, JWS or JWE payload is accepted.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// `incoming` - serialized message as `Message`/`Jws`/`Jws`
+    /// * `incoming` - serialized message as `Message`/`Jws`/`Jws`
     ///
-    /// `encryption_receiver_private_key` - receivers private key, used to decrypt `kek` in JWE
+    /// * `encryption_receiver_private_key` - receivers private key, used to decrypt `kek` in JWE
     ///
-    /// `encryption_sender_public_key` - senders public key, used to decrypt `kek` in JWE
+    /// * `encryption_sender_public_key` - senders public key, used to decrypt `kek` in JWE
     ///
-    /// `signing_sender_public_key` - senders public key, the JWS envelope was signed with
+    /// * `signing_sender_public_key` - senders public key, the JWS envelope was signed with
     pub fn receive(
         incoming: &str,
         encryption_receiver_private_key: Option<&[u8]>,
@@ -287,17 +289,17 @@ impl Message {
     /// Takes one mediator at a time to make sure that mediated chain preserves unchanged.
     /// This method can be chained any number of times to match all the mediators in the chain.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// `ek` - encryption key for inner message payload JWE encryption
+    /// * `ek` - encryption key for inner message payload JWE encryption
     ///
-    /// `to` - list of destination recipients. can be empty (Optional) `String::default()`
+    /// * `mediator_did` - DID of message mediator, will be `to` of mediated envelope
     ///
-    /// `form` - used same as in wrapped message, fails if not present with `DidResolveFailed` error.
+    /// * `mediator_public_key` - key used to encrypt content encryption key for mediator;
+    ///                           can be provided if key should not be resolved via mediators DID
     ///
-    /// `recipient_public_key` - can be provided if key should not be resolved via recipients DID
-    ///
-    /// TODO: Add examples
+    /// * `recipient_public_key` - key used to encrypt content encryption key for recipient;
+    ///                            can be provided if key should not be resolved via recipients DID
     pub fn routed_by(
         self,
         ek: &[u8],
@@ -320,10 +322,12 @@ impl Message {
 
     /// Seals self and returns ready to send JWE
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// `ek` - encryption key for inner message payload JWE encryption
-    // TODO: Add examples
+    /// * `sk` - encryption key for inner message payload JWE encryption
+    ///
+    /// * `recipient_public_key` - key used to encrypt content encryption key for recipient;
+    ///                            can be provided if key should not be resolved via recipients DID
     pub fn seal(
         mut self,
         sk: impl AsRef<[u8]>,
@@ -361,16 +365,17 @@ impl Message {
     /// Signs raw message and then packs it to encrypted envelope
     /// [Spec](https://identity.foundation/didcomm-messaging/spec/#message-signing)
     ///
-    /// # Parameters
+    /// # Arguments
     ///
-    /// `ek` - encryption key for inner message payload JWE encryption
+    /// * `ek` - encryption key for inner message payload JWE encryption
     ///
-    /// `signing_sender_private_key` - signing key for enveloped message JWS encryption
+    /// * `signing_sender_private_key` - signing key for enveloped message JWS encryption
     ///
-    /// `alg` - encryption algorithm used
+    /// * `signing_algorithm` - encryption algorithm used
     ///
-    /// `recipient_public_key` - can be provided if key should not be resolved via recipients DID
-    /// TODO: Add examples
+    /// * `encryption_recipient_public_key` - key used to encrypt content encryption key for
+    ///                                       recipient with; can be provided if key should not be
+    ///                                       resolved via recipients DID
     pub fn seal_signed(
         self,
         ek: &[u8],

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -145,7 +145,7 @@ impl Message {
         self
     }
 
-    /// Creates set of Jwm related headers for the JWE
+    /// Creates set of JWM related headers for the JWE
     /// Modifies JWM related header portion to match
     ///     encryption implementation and leaves other
     ///     parts unchanged.  TODO + FIXME: complete implementation

--- a/src/messages/message_raw_crypto.rs
+++ b/src/messages/message_raw_crypto.rs
@@ -92,7 +92,7 @@ impl Message {
     ///
     /// * `received_message` - received message as byte array
     ///
-    /// * `decryptor` - decryptor that should be used
+    /// * `decrypter` - decrypter that should be used
     ///
     /// * `cek` - content encryption key to decrypt message with
     pub fn decrypt(
@@ -255,7 +255,7 @@ mod raw_tests {
                     .map_err(|e| Error::Generic(e.to_string()))
             },
         );
-        // Pluggable decryptor function to decrypt data
+        // Pluggable decrypter function to decrypt data
         let my_decrypter = Box::new(
             |n: &[u8], k: &[u8], m: &[u8], _a: &[u8]| -> Result<Vec<u8>, Error> {
                 let aead = XChaCha20Poly1305::new(k.into());
@@ -289,7 +289,7 @@ mod raw_tests {
                 ))
             },
         );
-        // Pluggable decryptor function to decrypt data
+        // Pluggable decrypter function to decrypt data
         let my_decrypter = Box::new(
             |n: &[u8], k: &[u8], m: &[u8], _a: &[u8]| -> Result<Vec<u8>, Error> {
                 let nonce = secretbox::Nonce::from_slice(n).unwrap();
@@ -332,7 +332,7 @@ mod raw_tests {
                     .map_err(|e| Error::Generic(e.to_string()))
             },
         );
-        // Pluggable decryptor function to decrypt data
+        // Pluggable decrypter function to decrypt data
         let my_decrypter = Box::new(
             |n: &[u8], k: &[u8], m: &[u8], _a: &[u8]| -> Result<Vec<u8>, Error> {
                 let aead = XChaCha20Poly1305::new(k.into());

--- a/src/messages/message_raw_crypto.rs
+++ b/src/messages/message_raw_crypto.rs
@@ -117,7 +117,7 @@ impl Message {
             .ok_or_else(|| "JWE is missing tag")
             .map_err(|e| Error::Generic(e.to_string()))?;
         let mut ciphertext_and_tag: Vec<u8> = vec![];
-        ciphertext_and_tag.extend(&jwe.payload());
+        ciphertext_and_tag.extend(&jwe.get_payload());
         ciphertext_and_tag.extend(&decode(&tag)?);
 
         return match decrypter(jwe.get_iv().as_ref(), key, &ciphertext_and_tag, &aad) {

--- a/src/messages/message_raw_crypto.rs
+++ b/src/messages/message_raw_crypto.rs
@@ -187,7 +187,7 @@ impl Message {
 
         let mut verified = false;
         for signature_value in signatures_values_to_verify.clone() {
-            let alg = &signature_value.alg().ok_or(Error::JweParseError)?;
+            let alg = &signature_value.get_alg().ok_or(Error::JweParseError)?;
             let signature = &signature_value.signature[..];
             let verifier: SignatureAlgorithm = alg.try_into()?;
             let protected_header = signature_value

--- a/src/messages/message_raw_crypto.rs
+++ b/src/messages/message_raw_crypto.rs
@@ -4,11 +4,8 @@ use base64_url::{decode, encode};
 use serde_json::Value;
 
 use super::Message;
-#[cfg(feature = "resolve")]
-use crate::Recipient;
 use crate::{
     crypto::{SignatureAlgorithm, Signer, SigningMethod, SymmetricCypherMethod},
-    DidCommHeader,
     Error,
     Jwe,
     JwmHeader,
@@ -16,18 +13,6 @@ use crate::{
     MessageType,
     Signature,
 };
-
-#[derive(Serialize, Deserialize)]
-pub struct PayloadToVerify {
-    #[serde(flatten)]
-    didcomm_header: DidCommHeader,
-
-    #[cfg(feature = "resolve")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) recipients: Option<Vec<Recipient>>,
-
-    body: Value,
-}
 
 // struct docu is placed in `message.rs`
 #[cfg(feature = "raw-crypto")]

--- a/src/messages/message_raw_crypto.rs
+++ b/src/messages/message_raw_crypto.rs
@@ -214,6 +214,12 @@ impl Message {
     /// Verifies signature and returns payload message on verification success.
     /// `Err` return if signature invalid or data is malformed.
     /// Expects Jws's payload to be a valid serialized `Message` and base64_url encoded.
+    ///
+    /// # Arguments
+    ///
+    /// * `jws` - to be verified jws message as json `Value` object
+    ///
+    /// * `signing_sender_public_key` - optional public key used for verification, if `None` it will try to resolve the did in the `kid` field
     pub fn verify_value(jws: &Value, signing_sender_public_key: &[u8]) -> Result<Message, Error> {
         let jws_string = serde_json::to_string(jws)?;
         Message::verify(&jws_string.into_bytes(), signing_sender_public_key)

--- a/src/messages/message_raw_crypto.rs
+++ b/src/messages/message_raw_crypto.rs
@@ -22,7 +22,7 @@ impl Message {
     ///     the encryption. Agnostic of actual algorithm used.
     /// Consuming is to make sure no changes are
     ///     possible post packaging / sending.
-    /// Returns `(JwmHeader, Vec<u8>)` to be sent to receiver.
+    /// Returns `(JwmHeader, Vec<u8>)` to be sent to recipient.
     ///
     /// # Arguments
     ///
@@ -311,10 +311,10 @@ mod raw_tests {
         // Arrange
         let sender_sk = EphemeralSecret::new(rand_core::OsRng);
         let sender_pk = PublicKey::from(&sender_sk);
-        let receiver_sk = EphemeralSecret::new(rand_core::OsRng);
-        let receiver_pk = PublicKey::from(&receiver_sk);
-        let sender_shared = sender_sk.diffie_hellman(&receiver_pk);
-        let receiver_shared = receiver_sk.diffie_hellman(&sender_pk);
+        let recipient_sk = EphemeralSecret::new(rand_core::OsRng);
+        let recipient_pk = PublicKey::from(&recipient_sk);
+        let sender_shared = sender_sk.diffie_hellman(&recipient_pk);
+        let recipient_shared = recipient_sk.diffie_hellman(&sender_pk);
         let m = Message::new().as_jwe(&CryptoAlgorithm::XC20P, None);
         let id = m.get_didcomm_header().id.to_owned();
         // Pluggable encryptor function to encrypt data
@@ -342,7 +342,7 @@ mod raw_tests {
         let raw_m = Message::decrypt(
             &encrypted.unwrap().as_bytes(),
             my_decrypter,
-            receiver_shared.as_bytes(),
+            recipient_shared.as_bytes(),
         );
         assert!(&raw_m.is_ok()); // Decryption check
         assert_eq!(id, raw_m.unwrap().get_didcomm_header().id); // Data consistency check

--- a/src/messages/message_raw_crypto.rs
+++ b/src/messages/message_raw_crypto.rs
@@ -29,6 +29,7 @@ pub struct PayloadToVerify {
     body: Value,
 }
 
+// struct docu is placed in `message.rs`
 #[cfg(feature = "raw-crypto")]
 impl Message {
     /// Encrypts current message by consuming it.

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -16,6 +16,7 @@ pub use message::*;
 #[cfg(feature = "raw-crypto")]
 pub use message_raw_crypto::*;
 
+/// trait that can be used to verify body, see example [here][crate]
 pub trait Shape: Sized {
     type Err;
 

--- a/tests/jwe_envelopes.rs
+++ b/tests/jwe_envelopes.rs
@@ -66,7 +66,7 @@ fn can_receive_flat_jwe_json() -> Result<(), Error> {
     let message = Message::new()
         .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
         .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
-        .set_body(&body) // packing in some payload
+        .body(&body) // packing in some payload
         .as_flat_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 

--- a/tests/message_type.rs
+++ b/tests/message_type.rs
@@ -210,7 +210,7 @@ fn serializes_existing_body_as_object() -> Result<(), Error> {
     let message = Message::new()
         .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
         .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
-        .set_body(r#"{"foo":"bar"}"#);
+        .body(r#"{"foo":"bar"}"#);
 
     let jwm_string: String = serde_json::to_string(&message)?;
     let jwm_object: Value = serde_json::from_str(&jwm_string)?;

--- a/tests/message_type.rs
+++ b/tests/message_type.rs
@@ -182,7 +182,10 @@ fn keeps_inner_message_type_as_plain_for_signed_messages() -> Result<(), Error> 
 
     assert_eq!(jws_jwm_header.typ, MessageType::DidCommJws);
     assert_eq!(payload_jwm_header.typ, MessageType::DidCommRaw);
-    assert_eq!(received_message.jwm_header.typ, MessageType::DidCommRaw);
+    assert_eq!(
+        received_message.get_jwm_header().typ,
+        MessageType::DidCommRaw
+    );
 
     Ok(())
 }

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -21,7 +21,7 @@ fn send_receive_raw() {
             "did::xyz:34r3cu403hnth03r49g03",
             "did:xyz:30489jnutnjqhiu0uh540u8hunoe",
         ])
-        .set_body(sample_dids::TEST_DID_ENCRYPT_1);
+        .body(sample_dids::TEST_DID_ENCRYPT_1);
 
     // Act
     let ready_to_send = m.clone().as_raw_json().unwrap();
@@ -57,7 +57,7 @@ fn send_receive_encrypted_xc20p_json_test() {
             "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp",
             "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
         ]) // setting to
-        .set_body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
+        .body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
         .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
         .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
         .add_header_field("another_key".into(), "another_value".into()) // another coustom header
@@ -139,7 +139,7 @@ fn send_receive_signed_json_test() {
             "did::xyz:34r3cu403hnth03r49g03",
             "did:xyz:30489jnutnjqhiu0uh540u8hunoe",
         ]) // setting to
-        .set_body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
+        .body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
         .as_jws(&SignatureAlgorithm::EdDsa)
         .sign(SignatureAlgorithm::EdDsa.signer(), &sign_keypair.to_bytes());
 
@@ -180,7 +180,7 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
             "did::xyz:34r3cu403hnth03r49g03",
             "did:xyz:30489jnutnjqhiu0uh540u8hunoe",
         ]) // setting to
-        .set_body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
+        .body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
         .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
         .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
         .add_header_field("another_key".into(), "another_value".into()) // another custom header

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -38,7 +38,7 @@ fn send_receive_raw() {
 }
 
 #[test]
-fn send_receive_mediated_encrypted_xc20p_json_test_new() {
+fn send_receive_mediated_encrypted_xc20p_json_test() {
     let KeyPairSet {
         alice_private,
         alice_public,
@@ -83,65 +83,6 @@ fn send_receive_mediated_encrypted_xc20p_json_test_new() {
     );
     assert!(bob_received.is_ok());
 }
-
-// #[test]
-// #[cfg(not(feature = "resolve"))]
-// fn send_receive_mediated_encrypted_xc20p_json_test() {
-//     // Arrange
-//     // keys
-//     let alice_secret = EphemeralSecret::new(OsRng);
-//     let alice_public = PublicKey::from(&alice_secret);
-//     let alice_secret_2 = EphemeralSecret::new(OsRng);
-//     let alice_public_2 = PublicKey::from(&alice_secret_2);
-//     let bob_mediator_secret = EphemeralSecret::new(OsRng);
-//     let bob_mediator_public = PublicKey::from(&bob_mediator_secret);
-//     let bob_secret = EphemeralSecret::new(OsRng);
-//     let bob_public = PublicKey::from(&bob_secret);
-//     // DIDComm related setup
-//     let ek_to_bob = alice_secret.diffie_hellman(&bob_public);
-//     let ek_to_mediator = alice_secret_2.diffie_hellman(&bob_mediator_public);
-
-//     // Message construction
-//     let sealed = Message::new() // creating message
-//         .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp") // setting from
-//         .to(&["did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp", "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"]) // setting to
-//         .set_body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
-//         .as_jwe(&CryptoAlgorithm::XC20P, Some(&bob_public.to_bytes())) // set JOSE header for XC20P algorithm
-//         .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
-//         .add_header_field("another_key".into(), "another_value".into()) // another custom header
-//         .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#) // set kid header
-//         .routed_by(ek_to_bob.as_bytes(), "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf", Some(&bob_mediator_public.to_bytes())); // here we use destination key to bob and `to` header of mediator
-
-//     // Act + Assert as we go
-//     assert!(&sealed.is_ok());
-
-//     // Message envelope to mediator
-//     let message_object: Message = serde_json::from_str(&message.unwrap()).unwrap();
-//     let ready_to_send = message_object
-//         .as_jwe(&CryptoAlgorithm::XC20P, Some(&bob_mediator_public.to_bytes())) // here this method call is crucial as mediator and end receiver may use different algorithms.
-//         .seal(ek_to_mediator.as_bytes(), Some(&bob_mediator_public.to_bytes())); // this would've failed without previous method call.
-
-//     assert!(&ready_to_send.is_ok());
-
-//     // Received by mediator
-//     let rk_mediator = bob_mediator_secret.diffie_hellman(&alice_public_2); // key to decrypt mediated message
-//     #[cfg(not(feature = "resolve"))]
-//     let received_mediated = Message::receive(&ready_to_send.unwrap(), rk_mediator.as_bytes(), Some(&bob_mediator_public.to_bytes()));
-//     #[cfg(feature = "resolve")]
-//     let received_mediated = Message::receive(&ready_to_send.unwrap(), &"ACa4PPJ1LnPNq1iwS33V3Akh7WtnC71WkKFZ9ccM6sX2".from_base58().unwrap());
-
-//     assert!(&received_mediated.is_ok());
-
-//     // Received by Bob
-//     let rk_bob = bob_secret.diffie_hellman(&alice_public); // key to decrypt final message
-//     #[cfg(not(feature = "resolve"))]
-//     let received_bob = Message::receive(&String::from_utf8_lossy(&received_mediated.unwrap().get_body().unwrap().as_ref()), rk_bob.as_bytes(), None);
-//     #[cfg(feature = "resolve")]
-//     let received_bob = Message::receive(&String::from_utf8_lossy(&received_mediated.unwrap().body), &"HBTcN2MrXNRj9xF9oi8QqYyuEPv3JLLjQKuEgW9oxVKP".from_base58().unwrap());
-
-//     assert!(&received_bob.is_ok());
-//     assert_eq!(received_bob.unwrap().get_body().unwrap(), sample_dids::TEST_DID_SIGN_1);
-// }
 
 #[test]
 #[cfg(not(feature = "resolve"))]

--- a/tests/shape.rs
+++ b/tests/shape.rs
@@ -24,7 +24,7 @@ fn shape_desired_test() {
         num_field: 42,
         string_field: "important data".into(),
     };
-    let m = Message::new().set_body(&serde_json::to_string(&initial_shape).unwrap());
+    let m = Message::new().body(&serde_json::to_string(&initial_shape).unwrap());
 
     // -- pack, send, receive happens here
 


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Updates documentation and aligns naming.

## Details

<!--- HOW does it change stuff? -->
- update examples in readme
- copy ( :slightly_frowning_face: ) readme as create docu into `lib.rs`, update examples to be runnable tests
- future updates on readme should be done like: update `lib.rs` first and then copy (and cleanup) to readme or update both
- update function docu style
- add more function/module/etc. documentation
- cleanup re-exports
- remove unsused type
- align variable naming, e.g. use more descriptive names for keys, use `recipient` instead of `receiver`