### PR TITLE
Update sealing and signing arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ let mediated = Message::new()
     //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
     .routed_by(
         &alice_private,
+        Some(&bobs_public),
         "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
         Some(&mediators_public),
-        Some(&bobs_public),
     );
 assert!(mediated.is_ok());
 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ let message = Message::new() // creating message
 
 // Send as signed and encrypted JWS wrapped into JWE
 let ready_to_send = message.seal_signed(
-    SignatureAlgorithm::EdDsa,
-    &sign_keypair.to_bytes(),
     &alice_private,
     Some(&bobs_public),
+    SignatureAlgorithm::EdDsa,
+    &sign_keypair.to_bytes(),
 ).unwrap();
 
 //... transport to destination is happening here ...

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ let message = Message::new() // creating message
 
 // Send as signed and encrypted JWS wrapped into JWE
 let ready_to_send = message.seal_signed(
-    &alice_private,
-    &sign_keypair.to_bytes(),
     SignatureAlgorithm::EdDsa,
+    &sign_keypair.to_bytes(),
+    &alice_private,
     Some(&bobs_public),
 ).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,9 +279,9 @@
 //!
 //! // Send as signed and encrypted JWS wrapped into JWE
 //! let ready_to_send = message.seal_signed(
-//!     &alice_private,
-//!     &sign_keypair.to_bytes(),
 //!     SignatureAlgorithm::EdDsa,
+//!     &sign_keypair.to_bytes(),
+//!     &alice_private,
 //!     Some(&bobs_public),
 //! ).unwrap();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,10 +279,10 @@
 //!
 //! // Send as signed and encrypted JWS wrapped into JWE
 //! let ready_to_send = message.seal_signed(
-//!     SignatureAlgorithm::EdDsa,
-//!     &sign_keypair.to_bytes(),
 //!     &alice_private,
 //!     Some(&bobs_public),
+//!     SignatureAlgorithm::EdDsa,
+//!     &sign_keypair.to_bytes(),
 //! ).unwrap();
 //!
 //! //... transport to destination is happening here ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,9 +191,9 @@
 //!     //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
 //!     .routed_by(
 //!         &alice_private,
+//!         Some(&bobs_public),
 //!         "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
 //!         Some(&mediators_public),
-//!         Some(&bobs_public),
 //!     );
 //! assert!(mediated.is_ok());
 //!

--- a/src/messages/helpers/receive.rs
+++ b/src/messages/helpers/receive.rs
@@ -59,13 +59,11 @@ pub(crate) fn get_message_type(message: &str) -> Result<MessageType, Error> {
 ///                                    should be automatically resolved (requires `resolve` feature)
 pub(crate) fn receive_jwe(
     incoming: &str,
-    encryption_recipient_private_key: Option<&[u8]>,
+    encryption_recipient_private_key: &[u8],
     encryption_sender_public_key: Option<&[u8]>,
 ) -> Result<String, Error> {
     let jwe: Jwe = serde_json::from_str(incoming)?;
     let alg = &jwe.get_alg().ok_or(Error::JweParseError)?;
-    let recipient_private_key = encryption_recipient_private_key
-        .ok_or_else(|| Error::Generic("missing encryption recipient private key".to_string()))?;
 
     // get public key from input or from senders DID document
     let sender_public_key = match encryption_sender_public_key {
@@ -88,7 +86,7 @@ pub(crate) fn receive_jwe(
         }
     };
 
-    let shared = StaticSecret::from(array_ref!(recipient_private_key, 0, 32).to_owned())
+    let shared = StaticSecret::from(array_ref!(encryption_recipient_private_key, 0, 32).to_owned())
         .diffie_hellman(&PublicKey::from(
             array_ref!(sender_public_key, 0, 32).to_owned(),
         ));
@@ -107,7 +105,7 @@ pub(crate) fn receive_jwe(
         for recipient in recipients {
             let decrypted_key = decrypt_cek(
                 &jwe,
-                &recipient_private_key,
+                &encryption_recipient_private_key,
                 &recipient,
                 encryption_sender_public_key,
             );

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -401,20 +401,20 @@ impl Message {
     ///
     /// # Arguments
     ///
-    /// * `encryption_sender_private_key` - encryption key for inner message payload JWE encryption
+    /// * `signing_algorithm` - encryption algorithm used
     ///
     /// * `signing_sender_private_key` - signing key for enveloped message JWS encryption
     ///
-    /// * `signing_algorithm` - encryption algorithm used
+    /// * `encryption_sender_private_key` - encryption key for inner message payload JWE encryption
     ///
     /// * `encryption_recipient_public_key` - key used to encrypt content encryption key for
     ///                                       recipient with; can be provided if key should not be
     ///                                       resolved via recipients DID
     pub fn seal_signed(
         self,
-        encryption_sender_private_key: &[u8],
-        signing_sender_private_key: &[u8],
         signing_algorithm: SignatureAlgorithm,
+        signing_sender_private_key: &[u8],
+        encryption_sender_private_key: &[u8],
         encryption_recipient_public_key: Option<&[u8]>,
     ) -> Result<String, Error> {
         let mut to = self.clone();
@@ -701,9 +701,9 @@ mod crypto_tests {
             .kid(&hex::encode(vec![1; 32])); // invalid key, passing no key will not succeed
 
         let jwe_string = message.seal_signed(
-            &alice_private,
-            &sign_keypair.to_bytes(),
             SignatureAlgorithm::EdDsa,
+            &sign_keypair.to_bytes(),
+            &alice_private,
             Some(&bobs_public),
         )?;
 

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -293,9 +293,12 @@ impl Message {
         let mut current_message: String = incoming.to_string();
 
         if get_message_type(&current_message)? == MessageType::DidCommJwe {
+            let recipient_private_key = encryption_recipient_private_key.ok_or_else(|| {
+                Error::Generic("missing encryption recipient private key".to_string())
+            })?;
             current_message = receive_jwe(
                 &current_message,
-                encryption_recipient_private_key,
+                recipient_private_key,
                 encryption_sender_public_key,
             )?;
         }

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -401,21 +401,21 @@ impl Message {
     ///
     /// # Arguments
     ///
-    /// * `signing_algorithm` - encryption algorithm used
-    ///
-    /// * `signing_sender_private_key` - signing key for enveloped message JWS encryption
-    ///
     /// * `encryption_sender_private_key` - encryption key for inner message payload JWE encryption
     ///
     /// * `encryption_recipient_public_key` - key used to encrypt content encryption key for
     ///                                       recipient with; can be provided if key should not be
     ///                                       resolved via recipients DID
+    ///
+    /// * `signing_algorithm` - encryption algorithm used
+    ///
+    /// * `signing_sender_private_key` - signing key for enveloped message JWS encryption
     pub fn seal_signed(
         self,
-        signing_algorithm: SignatureAlgorithm,
-        signing_sender_private_key: &[u8],
         encryption_sender_private_key: &[u8],
         encryption_recipient_public_key: Option<&[u8]>,
+        signing_algorithm: SignatureAlgorithm,
+        signing_sender_private_key: &[u8],
     ) -> Result<String, Error> {
         let mut to = self.clone();
         let signed = self
@@ -701,10 +701,10 @@ mod crypto_tests {
             .kid(&hex::encode(vec![1; 32])); // invalid key, passing no key will not succeed
 
         let jwe_string = message.seal_signed(
-            SignatureAlgorithm::EdDsa,
-            &sign_keypair.to_bytes(),
             &alice_private,
             Some(&bobs_public),
+            SignatureAlgorithm::EdDsa,
+            &sign_keypair.to_bytes(),
         )?;
 
         let received_failure_no_key =

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -318,19 +318,19 @@ impl Message {
     ///
     /// * `sender_private_key` - encryption key for inner message payload JWE encryption
     ///
+    /// * `recipient_public_key` - key used to encrypt content encryption key for recipient;
+    ///                            can be provided if key should not be resolved via recipients DID
+    ///
     /// * `mediator_did` - DID of message mediator, will be `to` of mediated envelope
     ///
     /// * `mediator_public_key` - key used to encrypt content encryption key for mediator;
     ///                           can be provided if key should not be resolved via mediators DID
-    ///
-    /// * `recipient_public_key` - key used to encrypt content encryption key for recipient;
-    ///                            can be provided if key should not be resolved via recipients DID
     pub fn routed_by(
         self,
         sender_private_key: &[u8],
+        recipient_public_key: Option<&[u8]>,
         mediator_did: &str,
         mediator_public_key: Option<&[u8]>,
-        recipient_public_key: Option<&[u8]>,
     ) -> Result<String, Error> {
         let from = &self.didcomm_header.from.clone().unwrap_or_default();
         let alg = get_crypter_from_header(&self.jwm_header)?;
@@ -655,8 +655,8 @@ mod crypto_tests {
             .as_jwe(&CryptoAlgorithm::XC20P, None)
             .routed_by(
                 &alice_private,
-                "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
                 None,
+                "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
                 None,
             );
         assert!(sealed.is_ok());

--- a/tests/jwe_envelopes.rs
+++ b/tests/jwe_envelopes.rs
@@ -25,10 +25,10 @@ fn can_create_flat_jwe_json() -> Result<(), Error> {
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
-        SignatureAlgorithm::EdDsa,
-        &sign_keypair.to_bytes(),
         &alice_private,
         Some(&bobs_public),
+        SignatureAlgorithm::EdDsa,
+        &sign_keypair.to_bytes(),
     )?;
 
     let jwe_object: Value = serde_json::from_str(&jwe_string)?;
@@ -71,10 +71,10 @@ fn can_receive_flat_jwe_json() -> Result<(), Error> {
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
-        SignatureAlgorithm::EdDsa,
-        &sign_keypair.to_bytes(),
         &alice_private,
         Some(&bobs_public),
+        SignatureAlgorithm::EdDsa,
+        &sign_keypair.to_bytes(),
     )?;
 
     let received = Message::receive(&jwe_string, Some(&bobs_private), Some(&alice_public), None);

--- a/tests/jwe_envelopes.rs
+++ b/tests/jwe_envelopes.rs
@@ -25,9 +25,9 @@ fn can_create_flat_jwe_json() -> Result<(), Error> {
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
-        &alice_private,
-        &sign_keypair.to_bytes(),
         SignatureAlgorithm::EdDsa,
+        &sign_keypair.to_bytes(),
+        &alice_private,
         Some(&bobs_public),
     )?;
 
@@ -71,9 +71,9 @@ fn can_receive_flat_jwe_json() -> Result<(), Error> {
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
-        &alice_private,
-        &sign_keypair.to_bytes(),
         SignatureAlgorithm::EdDsa,
+        &sign_keypair.to_bytes(),
+        &alice_private,
         Some(&bobs_public),
     )?;
 

--- a/tests/message_type.rs
+++ b/tests/message_type.rs
@@ -78,9 +78,9 @@ fn sets_message_type_correctly_for_signed_and_encrypted_messages() -> Result<(),
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
-        &alice_private,
-        &sign_keypair.to_bytes(),
         SignatureAlgorithm::EdDsa,
+        &sign_keypair.to_bytes(),
+        &alice_private,
         Some(&bobs_public),
     )?;
 

--- a/tests/message_type.rs
+++ b/tests/message_type.rs
@@ -78,10 +78,10 @@ fn sets_message_type_correctly_for_signed_and_encrypted_messages() -> Result<(),
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
-        SignatureAlgorithm::EdDsa,
-        &sign_keypair.to_bytes(),
         &alice_private,
         Some(&bobs_public),
+        SignatureAlgorithm::EdDsa,
+        &sign_keypair.to_bytes(),
     )?;
 
     let jwe_object: Value = serde_json::from_str(&jwe_string)?;

--- a/tests/message_type.rs
+++ b/tests/message_type.rs
@@ -120,9 +120,9 @@ fn sets_message_type_correctly_for_forwarded_messages() -> Result<(), Error> {
 
     let jwe_string = message.routed_by(
         &alice_private,
+        Some(&bobs_public),
         "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
         Some(&mediators_public),
-        Some(&bobs_public),
     )?;
 
     let jwe_object: Value = serde_json::from_str(&jwe_string)?;

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -190,10 +190,10 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
     // Send
     let ready_to_send = message
         .seal_signed(
-            SignatureAlgorithm::EdDsa,
-            &sign_keypair.to_bytes(),
             &alice_private,
             Some(&bobs_public),
+            SignatureAlgorithm::EdDsa,
+            &sign_keypair.to_bytes(),
         )
         .unwrap();
 

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -190,9 +190,9 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
     // Send
     let ready_to_send = message
         .seal_signed(
-            &alice_private,
-            &sign_keypair.to_bytes(),
             SignatureAlgorithm::EdDsa,
+            &sign_keypair.to_bytes(),
+            &alice_private,
             Some(&bobs_public),
         )
         .unwrap();

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -96,9 +96,9 @@ fn send_receive_mediated_encrypted_xc20p_json_test() {
         .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
         .routed_by(
             &alice_private,
+            Some(&bobs_public),
             "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
             Some(&mediators_public),
-            Some(&bobs_public),
         );
     assert!(sealed.is_ok());
 


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Reorder arguments for sealing, signing and receiving related functions.

## Details

<!--- HOW does it change stuff? -->

- common flow of arguments is now first sealing, then signing, as messages are not signed as a matter of course
- made `jwe_receive` receiver private key mandatory as it was already by logic