### PR TITLE
Add support for multiple recipient keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ let message = Message::new()
     .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#);
 
 // recipient public key is automatically resolved
-let ready_to_send = message.seal(&ek, Some(&bobs_public)).unwrap();
+let ready_to_send = message.seal(
+    &ek,
+    Some(vec![Some(&bobs_public), Some(&clarice_public)]),
+).unwrap();
 
 //... transport is happening here ...
 ```
@@ -122,7 +125,7 @@ let mediated = Message::new()
     //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
     .routed_by(
         &alice_private,
-        Some(&bobs_public),
+        Some(vec![Some(&bobs_public)]),
         "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
         Some(&mediators_public),
     );
@@ -189,7 +192,7 @@ let message = Message::new() // creating message
 // Send as signed and encrypted JWS wrapped into JWE
 let ready_to_send = message.seal_signed(
     &alice_private,
-    Some(&bobs_public),
+    Some(vec![Some(&bobs_public)]),
     SignatureAlgorithm::EdDsa,
     &sign_keypair.to_bytes(),
 ).unwrap();
@@ -253,7 +256,7 @@ When implemented - use them instead of `CryptoAlgorithm` and `SignatureAlgorithm
 
 ### GoTo: [full test][shape_desired_test]
 
-In most cases application implementation would prefer to have strongly typed body of the message instead of raw `String`.
+In most cases application implementation would prefer to have strongly typed body of the message instead of raw `Vec<u8>`.
 For this scenario `Shape` trait should be implemented for target type.
 
 * First, let's define our target type. JSON in this example.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ let message = Message::new()
 // recipient public key is automatically resolved
 let ready_to_send = message.seal(
     &ek,
-    Some(vec![Some(&bobs_public), Some(&clarice_public)]),
+    Some(vec![Some(&bobs_public), Some(&carol_public)]),
 ).unwrap();
 
 //... transport is happening here ...
@@ -233,7 +233,7 @@ let jwe = jwe.unwrap();
 
 // Each of the recipients receive it in same way as before (direct with single recipient)
 let received_first = Message::receive(&jwe, Some(&bobs_private), None, None);
-let received_second = Message::receive(&jwe, Some(&clarice_private), None, None);
+let received_second = Message::receive(&jwe, Some(&carol_private), None, None);
 
 // All good without any extra inputs
 assert!(received_first.is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //! #         }
 //! #     ]
 //! # }"###;
-//! # let KeyPairSet { bobs_public, mediators_public: clarice_public, .. } = get_keypair_set();
+//! # let KeyPairSet { bobs_public, mediators_public: carol_public, .. } = get_keypair_set();
 //! // sender key as bytes
 //! let ek = [130, 110, 93, 113, 105, 127, 4, 210, 65, 234, 112, 90, 150, 120, 189, 252, 212, 165, 30, 209, 194, 213, 81, 38, 250, 187, 216, 14, 246, 250, 166, 92];
 //!
@@ -108,7 +108,7 @@
 //! // recipient public key is automatically resolved
 //! let ready_to_send = message.seal(
 //!     &ek,
-//!     Some(vec![Some(&bobs_public), Some(&clarice_public)]),
+//!     Some(vec![Some(&bobs_public), Some(&carol_public)]),
 //! ).unwrap();
 //!
 //! //... transport is happening here ...
@@ -315,7 +315,7 @@
 # let KeyPairSet {
 #     alice_private,
 #     bobs_private,
-#     mediators_private: clarice_private,
+#     mediators_private: carol_private,
 #     ..
 # } = get_keypair_set();
 // Creating message with multiple recipients.
@@ -335,7 +335,7 @@ let jwe = jwe.unwrap();
 
 // Each of the recipients receive it in same way as before (direct with single recipient)
 let received_first = Message::receive(&jwe, Some(&bobs_private), None, None);
-let received_second = Message::receive(&jwe, Some(&clarice_private), None, None);
+let received_second = Message::receive(&jwe, Some(&carol_private), None, None);
 
 // All good without any extra inputs
 assert!(received_first.is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //! #         }
 //! #     ]
 //! # }"###;
-//! # let KeyPairSet { bobs_public, .. } = get_keypair_set();
+//! # let KeyPairSet { bobs_public, mediators_public: clarice_public, .. } = get_keypair_set();
 //! // sender key as bytes
 //! let ek = [130, 110, 93, 113, 105, 127, 4, 210, 65, 234, 112, 90, 150, 120, 189, 252, 212, 165, 30, 209, 194, 213, 81, 38, 250, 187, 216, 14, 246, 250, 166, 92];
 //!
@@ -106,7 +106,10 @@
 //!     .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#);
 //!
 //! // recipient public key is automatically resolved
-//! let ready_to_send = message.seal(&ek, Some(&bobs_public)).unwrap();
+//! let ready_to_send = message.seal(
+//!     &ek,
+//!     Some(vec![Some(&bobs_public), Some(&clarice_public)]),
+//! ).unwrap();
 //!
 //! //... transport is happening here ...
 //! ```
@@ -191,7 +194,7 @@
 //!     //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
 //!     .routed_by(
 //!         &alice_private,
-//!         Some(&bobs_public),
+//!         Some(vec![Some(&bobs_public)]),
 //!         "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
 //!         Some(&mediators_public),
 //!     );
@@ -280,7 +283,7 @@
 //! // Send as signed and encrypted JWS wrapped into JWE
 //! let ready_to_send = message.seal_signed(
 //!     &alice_private,
-//!     Some(&bobs_public),
+//!     Some(vec![Some(&bobs_public)]),
 //!     SignatureAlgorithm::EdDsa,
 //!     &sign_keypair.to_bytes(),
 //! ).unwrap();

--- a/tests/jwe_envelopes.rs
+++ b/tests/jwe_envelopes.rs
@@ -26,7 +26,7 @@ fn can_create_flat_jwe_json() -> Result<(), Error> {
 
     let jwe_string = message.seal_signed(
         &alice_private,
-        Some(&bobs_public),
+        Some(vec![Some(&bobs_public)]),
         SignatureAlgorithm::EdDsa,
         &sign_keypair.to_bytes(),
     )?;
@@ -72,7 +72,7 @@ fn can_receive_flat_jwe_json() -> Result<(), Error> {
 
     let jwe_string = message.seal_signed(
         &alice_private,
-        Some(&bobs_public),
+        Some(vec![Some(&bobs_public)]),
         SignatureAlgorithm::EdDsa,
         &sign_keypair.to_bytes(),
     )?;

--- a/tests/message_type.rs
+++ b/tests/message_type.rs
@@ -79,7 +79,7 @@ fn sets_message_type_correctly_for_signed_and_encrypted_messages() -> Result<(),
 
     let jwe_string = message.seal_signed(
         &alice_private,
-        Some(&bobs_public),
+        Some(vec![Some(&bobs_public)]),
         SignatureAlgorithm::EdDsa,
         &sign_keypair.to_bytes(),
     )?;
@@ -120,7 +120,7 @@ fn sets_message_type_correctly_for_forwarded_messages() -> Result<(), Error> {
 
     let jwe_string = message.routed_by(
         &alice_private,
-        Some(&bobs_public),
+        Some(vec![Some(&bobs_public)]),
         "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
         Some(&mediators_public),
     )?;

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -47,7 +47,7 @@ fn send_receive_encrypted_xc20p_json_test() {
         alice_public,
         bobs_private,
         bobs_public,
-        mediators_public: clarice_public,
+        mediators_public: carol_public,
         ..
     } = get_keypair_set();
 
@@ -68,7 +68,7 @@ fn send_receive_encrypted_xc20p_json_test() {
     let ready_to_send = message
         .seal(
             &alice_private,
-            Some(vec![Some(&bobs_public), Some(&clarice_public)]),
+            Some(vec![Some(&bobs_public), Some(&carol_public)]),
         )
         .unwrap();
     let received = Message::receive(
@@ -175,7 +175,7 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
         alice_private,
         bobs_private,
         bobs_public,
-        mediators_public: clarice_public,
+        mediators_public: carol_public,
         ..
     } = get_keypair_set();
     let sign_keypair = ed25519_dalek::Keypair::generate(&mut OsRng);
@@ -198,7 +198,7 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
     let ready_to_send = message
         .seal_signed(
             &alice_private,
-            Some(vec![Some(&bobs_public), Some(&clarice_public)]),
+            Some(vec![Some(&bobs_public), Some(&carol_public)]),
             SignatureAlgorithm::EdDsa,
             &sign_keypair.to_bytes(),
         )

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -47,6 +47,7 @@ fn send_receive_encrypted_xc20p_json_test() {
         alice_public,
         bobs_private,
         bobs_public,
+        mediators_public: clarice_public,
         ..
     } = get_keypair_set();
 
@@ -64,7 +65,12 @@ fn send_receive_encrypted_xc20p_json_test() {
         .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#); // set kid header
 
     // Act
-    let ready_to_send = message.seal(&alice_private, Some(&bobs_public)).unwrap();
+    let ready_to_send = message
+        .seal(
+            &alice_private,
+            Some(vec![Some(&bobs_public), Some(&clarice_public)]),
+        )
+        .unwrap();
     let received = Message::receive(
         &ready_to_send,
         Some(&bobs_private),
@@ -96,7 +102,7 @@ fn send_receive_mediated_encrypted_xc20p_json_test() {
         .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
         .routed_by(
             &alice_private,
-            Some(&bobs_public),
+            Some(vec![Some(&bobs_public)]),
             "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
             Some(&mediators_public),
         );
@@ -169,6 +175,7 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
         alice_private,
         bobs_private,
         bobs_public,
+        mediators_public: clarice_public,
         ..
     } = get_keypair_set();
     let sign_keypair = ed25519_dalek::Keypair::generate(&mut OsRng);
@@ -191,7 +198,7 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
     let ready_to_send = message
         .seal_signed(
             &alice_private,
-            Some(&bobs_public),
+            Some(vec![Some(&bobs_public), Some(&clarice_public)]),
             SignatureAlgorithm::EdDsa,
             &sign_keypair.to_bytes(),
         )


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Allows to pass multiple receiver public keys to encryption related functions to encrypt content encryption key properly per recipient.

## Details

<!--- HOW does it change stuff? -->

- keys are proved as an optional Vector with optional values
- if no keys Vector is given, all keys will be resolved automatically
- if keys Vector is passed, the number of keys and their order must match the `to` values, the values are either the keys as `Some` or `None` (to for automatic resolval)