### PR TITLE
Improve DID parse regex

### DIFF
--- a/src/crypto/encryptor.rs
+++ b/src/crypto/encryptor.rs
@@ -140,7 +140,7 @@ mod batteries_tests {
         assert!(&jwe.tag.is_some());
         let s = Message::decrypt(
             jwe_string.as_bytes(),
-            CryptoAlgorithm::XC20P.decryptor(),
+            CryptoAlgorithm::XC20P.decrypter(),
             key,
         )?;
         let received_payload = &s.get_body()?;
@@ -164,7 +164,7 @@ mod batteries_tests {
         assert!(&jwe.is_ok());
         let s = Message::decrypt(
             jwe.unwrap().as_bytes(),
-            CryptoAlgorithm::A256GCM.decryptor(),
+            CryptoAlgorithm::A256GCM.decrypter(),
             key,
         )?;
         let received_payload = &s.get_body()?;

--- a/src/messages/helpers/encryption.rs
+++ b/src/messages/helpers/encryption.rs
@@ -388,7 +388,7 @@ fn get_did_from_didurl(url: &str) -> String {
     let re = regex::Regex::new(
         r"(?x)
         ^
-        (?P<key_id>
+        (?P<did>
             did             # scheme
             :
             [a-z]+          # method
@@ -405,7 +405,7 @@ fn get_did_from_didurl(url: &str) -> String {
     .unwrap();
     match re.captures(url) {
         Some(s) => s
-            .name("key_id")
+            .name("did")
             .map(|v| v.as_str().to_string())
             .unwrap_or_else(|| String::default()),
         None => String::default(),


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Improve DID parse regex to support complex DIDs, e.g. DIDs with subdomains.

## Details

<!--- HOW does it change stuff? -->

- add more DID URL parts to regex
- rename function to reflect its behavior `get_key_id_from_didurl ` --> `get_did_from_didurl`
- fix naming decryptor --> decrypter