### PR TITLE
Return more detailed error messages for JWE receival

### DIFF
--- a/src/messages/helpers/encryption.rs
+++ b/src/messages/helpers/encryption.rs
@@ -388,7 +388,7 @@ fn get_did_from_didurl(url: &str) -> String {
     let re = regex::Regex::new(
         r"(?x)
         ^
-        (?P<key_id>
+        (?P<did>
             did             # scheme
             :
             [a-z]+          # method
@@ -405,7 +405,7 @@ fn get_did_from_didurl(url: &str) -> String {
     .unwrap();
     match re.captures(url) {
         Some(s) => s
-            .name("key_id")
+            .name("did")
             .map(|v| v.as_str().to_string())
             .unwrap_or_else(|| String::default()),
         None => String::default(),


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Use `Generic` error messages to create more descriptive error messages in `receive_jwe`.

## Details

<!--- HOW does it change stuff? -->

- add error description for missing alg header
- either use inner error or return "no receipients" error