### PR TITLE
Remove resolve feature on default, bump k256 and p256 modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ base64-url = "1.4.9"
 chacha20poly1305 = { version = "0.8", optional = true }
 aes-gcm = { version = "0.9.2", optional = true }
 libaes = { version = "0.6.1", optional = true }
-k256 = { version = "0.9.4", optional = true, features = ["ecdsa", "sha256", "zeroize"] }
-p256 = { version = "0.9.0", optional = true, features = ["ecdsa", "zeroize"] }
+k256 = { version = "^0.11.0", optional = true, features = ["ecdsa", "sha256"] }
+p256 = { version = "^0.11.0", optional = true, features = ["ecdsa"] }
 ed25519-dalek = { version = "1.0", optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
 ddoresolver-rs = { version = "0.4.2", default-features = false, features = ["didkey", "keriox"], optional = true }
@@ -59,7 +59,7 @@ default-features = false
 features = ["user-hooks"]
 
 [features]
-default = ["raw-crypto", "resolve", "out-of-band"]
+default = ["raw-crypto", "out-of-band"]
 raw-crypto = ["chacha20poly1305", "aes-gcm", "k256", "p256", "ed25519-dalek", "libaes"]
 resolve = ["ddoresolver-rs"]
 out-of-band = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ k256 = { version = "^0.11.0", optional = true, features = ["ecdsa", "sha256"] }
 p256 = { version = "^0.11.0", optional = true, features = ["ecdsa"] }
 ed25519-dalek = { version = "1.0", optional = true }
 hex = { version = "0.4.3", features = ["serde"] }
-ddoresolver-rs = { version = "0.4.2", default-features = false, features = ["didkey", "keriox"], optional = true }
 x25519-dalek = "1.1"
 arrayref = "0.3"
 chrono = "0.4"
@@ -61,5 +60,4 @@ features = ["user-hooks"]
 [features]
 default = ["raw-crypto", "out-of-band"]
 raw-crypto = ["chacha20poly1305", "aes-gcm", "k256", "p256", "ed25519-dalek", "libaes"]
-resolve = ["ddoresolver-rs"]
 out-of-band = []


### PR DESCRIPTION
# Details

Removes the `resolve` feature as default to be able to bump k256 and p256