### PR TITLE
Update dependencies and spec changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Raise pull requests for version updates
+    # to cargo against the `main` branch
+    target-branch: "main"
+    # Labels on pull requests for version updates only
+    labels:
+      - "cargo dependencies"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ sha2 = "0.8.1"
 # Other
 env_logger = "0.9.0"
 log = "0.4.8"
-regex = "1"
+regex = "1.5.5"
 rand = "0.8"
 rand_chacha = "0.3.0"
 thiserror = "1.0"

--- a/README.md
+++ b/README.md
@@ -387,6 +387,13 @@ let message = Message::new() // creating message
 let received_typed_body = DesiredShape::shape(&message).unwrap(); // Where m = Message
 ```
 
+## Unimplemented changes from spec v2.1
+
+DIDComm v2.1 [spec](https://identity.foundation/didcomm-messaging/spec/v2.1) has some changes which are unimplemented in the present `didcomm-rs` rust implementation.
+
+ - `body` element is optional. It can be left empty if absent, [link](https://identity.foundation/didcomm-messaging/spec/v2.1/#overview:~:text=body%20%2D-,OPTIONAL,-.%20The%20body%20attribute)
+ - `serviceEndpoint` has a minor variation in format, [link](https://identity.foundation/didcomm-messaging/spec/v2.1/#service-endpoint)
+
 ## Disclaimer
 
 This is a sample implementation of the DIDComm V2 spec. The DIDComm V2 spec is still actively being developed by the DIDComm WG in the DIF and therefore subject to change.


### PR DESCRIPTION
## Description
Current cargo dependency versions need to be updated and we need to check for regular security updates , so this MR adds  dependabot yml to check for security updates and new versions weekly. This MR also updates readme file for unimplemented didcomm [spec v2.1](https://identity.foundation/didcomm-messaging/spec/v2.1/) changes.

## Details
- Add dependabot
- Update cargo dependency
- Document unimplemented changes in spec v2.1